### PR TITLE
Apply Colors to Elements Outline Based on Tag Group

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Border Patrol - CSS Outliner & Debugging Tool",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Border Patrol is a browser extension that outlines every element on a webpage, helping developers and designers visualize layouts, margins, and padding instantly.",
   "permissions": ["scripting", "storage", "activeTab"],
   "host_permissions": ["<all_urls>"],

--- a/scripts/border.js
+++ b/scripts/border.js
@@ -23,6 +23,8 @@ chrome.runtime.sendMessage({ action: 'getTabId' }, async response => {
  * @param {number} size - The width of the outline in pixels.
  */
 function applyOutline(isEnabled, size = 1) {
+  const defaultColor = 'red'; // Fallback color if tag not found
+
   // Define element groups and their corresponding tags
   const elementGroups = {
     containers: ['div', 'section', 'article', 'header', 'footer', 'main'],
@@ -32,18 +34,18 @@ function applyOutline(isEnabled, size = 1) {
     interactive: ['a', 'form', 'input', 'textarea', 'select', 'button'],
   };
 
+  // Define colors for each element group
   const colors = {
     containers: 'blue',
-    tables: 'cyan',
+    tables: 'skyblue',
     text: 'green',
     media: 'purple',
     interactive: 'orange',
-    default: 'red', // Fallback color
   };
 
   document.querySelectorAll('*').forEach(element => {
     const tag = element.tagName.toLowerCase();
-    let color = colors.default; // Default color if tag not found
+    let color = defaultColor;
 
     for (const [group, tags] of Object.entries(elementGroups)) {
       if (tags.includes(tag)) {

--- a/scripts/border.js
+++ b/scripts/border.js
@@ -25,32 +25,40 @@ chrome.runtime.sendMessage({ action: 'getTabId' }, async response => {
 function applyOutline(isEnabled, size = 1) {
   const defaultColor = 'red'; // Fallback color if tag not found
 
-  // Define element groups and their corresponding tags
+  // Define element groups with their tags and colors
   const elementGroups = {
-    containers: ['div', 'section', 'article', 'header', 'footer', 'main'],
-    tables: ['table', 'tr', 'td', 'th'],
-    text: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li'],
-    media: ['img', 'picture', 'audio', 'video'],
-    interactive: ['a', 'form', 'input', 'textarea', 'select', 'button'],
+    containers: {
+      tags: ['div', 'section', 'article', 'header', 'footer', 'main'],
+      color: 'blue',
+    },
+    tables: {
+      tags: ['table', 'tr', 'td', 'th'],
+      color: 'skyblue',
+    },
+    text: {
+      tags: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li'],
+      color: 'green',
+    },
+    media: {
+      tags: ['img', 'picture', 'audio', 'video'],
+      color: 'purple',
+    },
+    interactive: {
+      tags: ['a', 'form', 'input', 'textarea', 'select', 'button'],
+      color: 'orange',
+    },
   };
 
-  // Define colors for each element group
-  const colors = {
-    containers: 'blue',
-    tables: 'skyblue',
-    text: 'green',
-    media: 'purple',
-    interactive: 'orange',
-  };
-
+  // Apply outline to all elements
   document.querySelectorAll('*').forEach(element => {
     const tag = element.tagName.toLowerCase();
     let color = defaultColor;
 
-    for (const [group, tags] of Object.entries(elementGroups)) {
+    // Determine element's group and apply corresponding color
+    for (const { tags, color: groupColor } of Object.values(elementGroups)) {
       if (tags.includes(tag)) {
-        color = colors[group];
-        break;
+        color = groupColor;
+        break; // Stop searching once a match is found
       }
     }
 

--- a/scripts/border.js
+++ b/scripts/border.js
@@ -12,8 +12,46 @@ chrome.runtime.sendMessage({ action: 'getTabId' }, async response => {
   const data = await chrome.storage.local.get(`isEnabled_${tabId}`);
   const isEnabled = data[`isEnabled_${tabId}`];
 
-  // Apply the outline to all elements if the extension is enabled
-  document.querySelectorAll('*').forEach(element => {
-    element.style.outline = isEnabled ? '1px solid red' : 'none';
-  });
+  applyOutline(isEnabled);
 });
+
+/**
+ * Applies an outline to all elements on the page.
+ *
+ * @param {boolean} isEnabled - Determines whether the outline should be applied.
+ * If true, an outline is applied to each element; otherwise, no outline is applied.
+ * @param {number} size - The width of the outline in pixels.
+ */
+function applyOutline(isEnabled, size = 1) {
+  // Define element groups and their corresponding tags
+  const elementGroups = {
+    containers: ['div', 'section', 'article', 'header', 'footer', 'main'],
+    tables: ['table', 'tr', 'td', 'th'],
+    text: ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li'],
+    media: ['img', 'picture', 'audio', 'video'],
+    interactive: ['a', 'form', 'input', 'textarea', 'select', 'button'],
+  };
+
+  const colors = {
+    containers: 'blue',
+    tables: 'cyan',
+    text: 'green',
+    media: 'purple',
+    interactive: 'orange',
+    default: 'red', // Fallback color
+  };
+
+  document.querySelectorAll('*').forEach(element => {
+    const tag = element.tagName.toLowerCase();
+    let color = colors.default; // Default color if tag not found
+
+    for (const [group, tags] of Object.entries(elementGroups)) {
+      if (tags.includes(tag)) {
+        color = colors[group];
+        break;
+      }
+    }
+
+    element.style.outline = isEnabled ? `${size}px solid ${color}` : 'none';
+  });
+}


### PR DESCRIPTION
## Overview
This PR improves the visual debugging experience by applying distinct outline colors to elements based on their category. Grouping similar elements makes it easier to identify the page structure at a glance.

## Changes:
Introduced element groupings with specific colors:

- Containers (`div, section, article, etc...`) → blue
- Tables (`table, tr, td, etc...`) → cyan
- Text (`p, h1-h6, li, etc...`) → green
- Media (`img, video, canvas, etc...`) → purple
- Interactive (`a, button, input, etc...`) → orange

Added a default red outline for uncategorized elements.

### Why?
This structured color-coding improves readability and debugging efficiency. 🚀
