### PR TITLE
Fix Inspector Mode Overlay Position on Scroll

### DIFF
--- a/css/overlay.css
+++ b/css/overlay.css
@@ -9,4 +9,15 @@
   pointer-events: none;
   z-index: 9999;
   max-width: 250px;
+  min-width: 150px;
+}
+
+#inspector-overlay-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  z-index: 10000;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Border Patrol - CSS Outliner & Debugging Tool",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Border Patrol is a browser extension that outlines every element on a webpage, helping developers and designers visualize layouts, margins, and padding instantly.",
   "permissions": ["scripting", "storage", "activeTab"],
   "host_permissions": ["<all_urls>"],

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -40,26 +40,25 @@
    */
   function getOverlayPosition(event, overlay) {
     if (!overlay) return { top: 0, left: 0 }; // Return default values
+    const overlayMargin = 10; // Overlay margin
 
-    // Calculate position of the overlay
-    let posX = event.clientX + window.scrollX + 10;
-    let posY = event.clientY + window.scrollY + 10;
+    // Calculate position of the overlay relative to the cursor
+    let posX = event.clientX + window.scrollX + overlayMargin;
+    let posY = event.clientY + window.scrollY + overlayMargin;
 
     // Prevent tooltip from going off-screen
     const overlayRect = overlay.getBoundingClientRect();
+
     // Flips the overlay to the left if it exceeds the right edge
     if (posX + overlayRect.width > window.innerWidth) {
-      posX = event.clientX - overlayRect.width - 10;
+      posX = event.clientX - overlayRect.width - overlayMargin;
     }
     // Flips the overlay upward if it exceeds the bottom edge
     if (posY + overlayRect.height > window.innerHeight) {
-      posY = event.clientY - overlayRect.height - 10;
+      posY = event.clientY - overlayRect.height - overlayMargin;
     }
 
-    return {
-      top: posY,
-      left: posX,
-    };
+    return { top: posY, left: posX };
   }
 
   /**

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -39,23 +39,24 @@
    * @returns {Object} The position of the overlay
    */
   function getOverlayPosition(event, overlay) {
-    if (!overlay) return { top: 0, left: 0 }; // Return default values
-    const overlayMargin = 10; // Overlay margin
+    if (!overlay) return { top: 0, left: 0 }; // Default values
+    const overlayMargin = 10; // Margin from cursor
 
     // Calculate position of the overlay relative to the cursor
     let posX = event.clientX + window.scrollX + overlayMargin;
     let posY = event.clientY + window.scrollY + overlayMargin;
 
-    // Prevent tooltip from going off-screen
+    // Prevent overlay from going off-screen
     const overlayRect = overlay.getBoundingClientRect();
 
-    // Flips the overlay to the left if it exceeds the right edge
+    // Flip left if overlay goes beyond right edge
     if (posX + overlayRect.width > window.innerWidth) {
-      posX = event.clientX - overlayRect.width - overlayMargin;
+      posX = event.clientX + window.scrollX - overlayRect.width - overlayMargin;
     }
-    // Flips the overlay upward if it exceeds the bottom edge
+    // Flip up if overlay goes beyond bottom edge
     if (posY + overlayRect.height > window.innerHeight) {
-      posY = event.clientY - overlayRect.height - overlayMargin;
+      posY =
+        event.clientY + window.scrollY - overlayRect.height - overlayMargin;
     }
 
     return { top: posY, left: posX };
@@ -91,11 +92,27 @@
     // console.log('rect:', rect);
     // console.log('computedStyle:', computedStyle);
 
+    let overlayContainer = document.getElementById(
+      'inspector-overlay-container'
+    );
+    if (!overlayContainer) {
+      overlayContainer = document.createElement('div');
+      overlayContainer.id = 'inspector-overlay-container';
+      document.body.appendChild(overlayContainer);
+    }
+
+    const bodyRect = document.body.getBoundingClientRect();
+    // Set position and size of the overlay container relative to the body
+    overlayContainer.style.top = `${bodyRect.top}px`;
+    overlayContainer.style.left = `${bodyRect.left}px`;
+    overlayContainer.style.width = `${bodyRect.width}px`;
+    overlayContainer.style.height = `${bodyRect.height}px`;
+
     let overlay = document.getElementById('inspector-overlay');
     if (!overlay) {
       overlay = document.createElement('div');
       overlay.id = 'inspector-overlay';
-      document.body.appendChild(overlay);
+      overlayContainer.appendChild(overlay);
     }
 
     overlay.innerHTML = `

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -33,33 +33,51 @@
   }
 
   /**
-   * Calculates the position of the overlay
+   * Calculates the position of the overlay relative to the cursor
+   * and prevents it from going off-screen
    * @param {*} event - The triggered event
    * @param {*} overlay - The overlay dom element
    * @returns {Object} The position of the overlay
    */
   function getOverlayPosition(event, overlay) {
     if (!overlay) return { top: 0, left: 0 }; // Default values
+
     const overlayMargin = 10; // Margin from cursor
+    const overlayRect = overlay.getBoundingClientRect();
 
     // Calculate position of the overlay relative to the cursor
-    let posX = event.clientX + window.scrollX + overlayMargin;
-    let posY = event.clientY + window.scrollY + overlayMargin;
-
-    // Prevent overlay from going off-screen
-    const overlayRect = overlay.getBoundingClientRect();
+    let posX = event.clientX + overlayMargin;
+    let posY = event.clientY + overlayMargin;
 
     // Flip left if overlay goes beyond right edge
     if (posX + overlayRect.width > window.innerWidth) {
-      posX = event.clientX + window.scrollX - overlayRect.width - overlayMargin;
-    }
-    // Flip up if overlay goes beyond bottom edge
-    if (posY + overlayRect.height > window.innerHeight) {
-      posY =
-        event.clientY + window.scrollY - overlayRect.height - overlayMargin;
+      posX = event.clientX - overlayRect.width - overlayMargin;
+      // console.log('Flipped left');
     }
 
-    return { top: posY, left: posX };
+    // Flip up if overlay goes beyond bottom edge
+    if (posY + overlayRect.height > window.innerHeight) {
+      posY = event.clientY - overlayRect.height - overlayMargin;
+      // console.log('Flipped up');
+    }
+
+    // console.log({
+    //   eventX: event.clientX,
+    //   eventY: event.clientY,
+    //   overlayWidth: overlayRect.width,
+    //   overlayHeight: overlayRect.height,
+    //   windowWidth: window.innerWidth,
+    //   windowHeight: window.innerHeight,
+    //   scrollX: window.scrollX,
+    //   scrollY: window.scrollY,
+    //   finalPosX: posX + window.scrollX,
+    //   finalPosY: posY + window.scrollY,
+    // });
+
+    return {
+      top: posY + window.scrollY,
+      left: posX + window.scrollX,
+    };
   }
 
   /**
@@ -123,6 +141,9 @@
     ${computedStyle.padding ? `Padding: ${computedStyle.padding}` : ''}
   `;
 
+    // Set display to block before getOverlayPosition
+    overlay.style.display = 'block';
+
     // Calculate position of the overlay
     const { top, left } = getOverlayPosition(event, overlay);
 
@@ -130,7 +151,7 @@
     requestAnimationFrame(() => {
       overlay.style.top = `${top}px`;
       overlay.style.left = `${left}px`;
-      overlay.style.display = 'block';
+      // overlay.style.display = 'block';
     });
   }
 

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -42,8 +42,8 @@
     if (!overlay) return { top: 0, left: 0 }; // Return default values
 
     // Calculate position of the overlay
-    let posX = event.clientX + 10;
-    let posY = event.clientY + 10;
+    let posX = event.clientX + window.scrollX + 10;
+    let posY = event.clientY + window.scrollY + 10;
 
     // Prevent tooltip from going off-screen
     const overlayRect = overlay.getBoundingClientRect();


### PR DESCRIPTION
## Issue
Inspector mode's overlay appears in the incorrect location when scrolling or if the console is open.

## Solution
- Added `window.scrollX` to `posX` and `window.scrollY` to `posY` when calculating the overlay's position.
- Set overlay display to block before getting position (`getOverlayPosition`) so that the overlay's `width` and `height` can be considered in the calculations
