### PR TITLE
Update Overlay Positioning for Smoother Visual Experience

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Border Patrol - CSS Outliner & Debugging Tool",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Border Patrol is a browser extension that outlines every element on a webpage, helping developers and designers visualize layouts, margins, and padding instantly.",
   "permissions": ["scripting", "storage", "activeTab"],
   "host_permissions": ["<all_urls>"],

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -159,7 +159,7 @@
 
     // Throttle the overlay position update
     if (throttleTimeout === null) {
-      let throttleTimeout = setTimeout(() => {
+      throttleTimeout = setTimeout(() => {
         updateOverlayPosition(event);
         throttleTimeout = null;
       }, THROTTLE_DELAY);

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -137,16 +137,24 @@
    */
   function updateOverlayPosition(event) {
     const overlay = document.getElementById('inspector-overlay');
-    if (overlay) {
-      // Calculate position of the overlay
-      const { top, left } = getOverlayPosition(event, overlay);
+    if (!overlay) return;
 
-      // Display the overlay
-      requestAnimationFrame(() => {
-        overlay.style.top = `${top}px`;
-        overlay.style.left = `${left}px`;
-      });
-    }
+    // Calculate position of the overlay
+    const { top, left } = getOverlayPosition(event, overlay);
+
+    // Display the overlay
+    requestAnimationFrame(() => {
+      overlay.style.top = `${top}px`;
+      overlay.style.left = `${left}px`;
+    });
+  }
+
+  /**
+   * Updates the position of the overlay on mousemove
+   * @param {*} event - The triggered event
+   */
+  function mouseMoveHandler(event) {
+    updateOverlayPosition(event);
   }
 
   /** Hides the overlay on mouseout */
@@ -158,13 +166,13 @@
   /** Removes event listeners */
   function removeEventListeners() {
     document.removeEventListener('mouseover', mouseOverHandler);
-    document.removeEventListener('mousemove', mouseOverHandler);
+    document.removeEventListener('mousemove', mouseMoveHandler);
     document.removeEventListener('mouseout', mouseOutHandler);
   }
 
   // Add event listeners
   document.addEventListener('mouseover', mouseOverHandler);
-  document.addEventListener('mousemove', mouseOverHandler);
+  document.addEventListener('mousemove', mouseMoveHandler);
   document.addEventListener('mouseout', mouseOutHandler);
 
   // Recieve message to update inspector mode

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -116,24 +116,37 @@
     }
 
     overlay.innerHTML = `
-    <strong>${element.tagName.toLowerCase()}</strong><br>
-    ${Math.round(rect.width)} x ${Math.round(rect.height)} px<br>
-    ${computedStyle.border ? `Border: ${computedStyle.border}<br>` : ''}
-    ${computedStyle.margin ? `Margin: ${computedStyle.margin}<br>` : ''}
-    ${computedStyle.padding ? `Padding: ${computedStyle.padding}` : ''}
-  `;
+      <strong>${element.tagName.toLowerCase()}</strong><br>
+      ${Math.round(rect.width)} x ${Math.round(rect.height)} px<br>
+      ${computedStyle.border ? `Border: ${computedStyle.border}<br>` : ''}
+      ${computedStyle.margin ? `Margin: ${computedStyle.margin}<br>` : ''}
+      ${computedStyle.padding ? `Padding: ${computedStyle.padding}` : ''}
+    `;
+
+    console.log('test');
 
     // Set display to block before getOverlayPosition
     overlay.style.display = 'block';
 
-    // Calculate position of the overlay
-    const { top, left } = getOverlayPosition(event, overlay);
+    updateOverlayPosition(event);
+  }
 
-    // Display the overlay
-    requestAnimationFrame(() => {
-      overlay.style.top = `${top}px`;
-      overlay.style.left = `${left}px`;
-    });
+  /**
+   * Updates the position of the overlay
+   * @param {*} event - The triggered event
+   */
+  function updateOverlayPosition(event) {
+    const overlay = document.getElementById('inspector-overlay');
+    if (overlay) {
+      // Calculate position of the overlay
+      const { top, left } = getOverlayPosition(event, overlay);
+
+      // Display the overlay
+      requestAnimationFrame(() => {
+        overlay.style.top = `${top}px`;
+        overlay.style.left = `${left}px`;
+      });
+    }
   }
 
   /** Hides the overlay on mouseout */
@@ -145,11 +158,13 @@
   /** Removes event listeners */
   function removeEventListeners() {
     document.removeEventListener('mouseover', mouseOverHandler);
+    document.removeEventListener('mousemove', mouseOverHandler);
     document.removeEventListener('mouseout', mouseOutHandler);
   }
 
   // Add event listeners
   document.addEventListener('mouseover', mouseOverHandler);
+  document.addEventListener('mousemove', mouseOverHandler);
   document.addEventListener('mouseout', mouseOutHandler);
 
   // Recieve message to update inspector mode

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -1,5 +1,8 @@
 (function () {
   let isInspectorModeEnabled = false; // Cache the inspector mode state
+  let throttleTimeout = null;
+
+  const THROTTLE_DELAY = 16; // Delay in milliseconds (16ms = 60fps)
 
   init();
 
@@ -123,8 +126,6 @@
       ${computedStyle.padding ? `Padding: ${computedStyle.padding}` : ''}
     `;
 
-    console.log('test');
-
     // Set display to block before getOverlayPosition
     overlay.style.display = 'block';
 
@@ -154,11 +155,20 @@
    * @param {*} event - The triggered event
    */
   function mouseMoveHandler(event) {
-    updateOverlayPosition(event);
+    if (!isInspectorModeEnabled) return;
+
+    // Throttle the overlay position update
+    if (throttleTimeout === null) {
+      let throttleTimeout = setTimeout(() => {
+        updateOverlayPosition(event);
+        throttleTimeout = null;
+      }, THROTTLE_DELAY);
+    }
   }
 
   /** Hides the overlay on mouseout */
   function mouseOutHandler() {
+    if (!isInspectorModeEnabled) return;
     const overlay = document.getElementById('inspector-overlay');
     if (overlay) overlay.style.display = 'none';
   }


### PR DESCRIPTION
## Overview

The overlay position doesn't update frequently, which causes the visual experience to seem delayed when moving around. 

## Solution

- Added a new event listener for `mousemove` to constantly update the overlay's position
- Added throttling for overlay repositioning on `mousemove` events
- Improved performance by adding early returns when the overlay option is disabled 
