### PR TITLE
Fix Inspector Mode Persistence After Extension Reload

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,6 @@
  * @param {boolean} isEnabled - Determines whether the extension is enabled or disabled.
  */
 function updateExtensionState(isEnabled) {
-  chrome.action.setBadgeText({ text: isEnabled ? 'ON' : 'OFF' });
   chrome.action.setIcon({
     path: isEnabled
       ? 'icons/border-patrol-icon-16.png'

--- a/background.js
+++ b/background.js
@@ -93,6 +93,27 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 
 /**
+ * Checks if the provided URL is a restricted URL.
+ * @param {string} url - The URL to check.
+ * @returns {boolean} True if the URL is restricted, false otherwise.
+ */
+function isRestrictedUrl(url) {
+  const invalidSchemes = [
+    'chrome:',
+    'chrome-extension:',
+    'about:',
+    'edge:',
+    'file:',
+  ];
+
+  return (
+    invalidSchemes.some(scheme => url.startsWith(scheme)) ||
+    url.startsWith('https://chrome.google.com/webstore') ||
+    url.startsWith('https://chromewebstore.google.com')
+  );
+}
+
+/**
  * Injects the border script into the specified tab.
  * @param {number} tabId - The ID of the tab to inject the script into.
  */
@@ -100,7 +121,7 @@ async function injectBorderScript(tabId) {
   try {
     // Check if the tab is a valid webpage
     const tab = await chrome.tabs.get(tabId);
-    if (!tab?.url || tab.url.startsWith('chrome://')) return;
+    if (!tab?.url || isRestrictedUrl(tab.url)) return;
 
     // Inject overlay.css into the active tab
     await chrome.scripting.insertCSS({

--- a/background.js
+++ b/background.js
@@ -131,11 +131,7 @@ async function sendInspectorModeUpdate(tabId) {
     const tab = await chrome.tabs.get(tabId);
     if (!tab?.url || tab.url.startsWith('chrome://')) return;
 
-    // Check if the chrome storage API is available
-    if (!chrome || !chrome.storage) {
-      console.warn('Chrome storage API unavailable in background.');
-      return;
-    }
+    if (!chrome || !chrome.storage) return;
 
     // Retrieve the inspector mode state
     const data = await chrome.storage.local.get('isInspectorModeEnabled');
@@ -147,8 +143,7 @@ async function sendInspectorModeUpdate(tabId) {
       isEnabled,
     });
   } catch (error) {
-    // TODO: Ignore error if tab is closed
-    console.error('Error sending inspector mode update:', error);
+    // Ignore errors if the tab is no longer active
   }
 }
 

--- a/background.js
+++ b/background.js
@@ -150,7 +150,7 @@ async function sendInspectorModeUpdate(tabId) {
   try {
     // Check if the tab is a valid webpage
     const tab = await chrome.tabs.get(tabId);
-    if (!tab?.url || tab.url.startsWith('chrome://')) return;
+    if (!tab?.url || isRestrictedUrl(tab.url)) return;
 
     if (!chrome || !chrome.storage) return;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Border Patrol - CSS Outliner & Debugging Tool",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Border Patrol is a browser extension that outlines every element on a webpage, helping developers and designers visualize layouts, margins, and padding instantly.",
   "permissions": ["scripting", "storage", "activeTab"],
   "host_permissions": ["<all_urls>"],

--- a/manifest.json
+++ b/manifest.json
@@ -27,5 +27,17 @@
       },
       "description": "Toggle Border Patrol"
     }
-  }
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "exclude_matches": [
+        "https://chrome.google.com/webstore*",
+        "https://chromewebstore.google.com/*"
+      ],
+      "css": ["css/overlay.css"],
+      "js": ["scripts/border.js", "scripts/overlay.js"],
+      "run_at": "document_end"
+    }
+  ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
     "default_popup": "menu.html"
   },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "icons": {
     "16": "icons/border-patrol-icon-16.png",

--- a/scripts/border.js
+++ b/scripts/border.js
@@ -91,7 +91,6 @@ chrome.runtime.sendMessage({ action: 'GET_TAB_ID' }, async response => {
 
 // Receive message to apply outline to all elements
 chrome.runtime.onMessage.addListener(async request => {
-  // console.log('Received message:', request);
   if (request.action === 'UPDATE_SETTINGS') {
     let { borderThickness, borderStyle, tabId } = request;
     const data = await chrome.storage.local.get(`isEnabled_${tabId}`);

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -62,6 +62,8 @@ async function toggleInspectorMode() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tab) return;
 
+  if (!tab?.url || tab.url.startsWith('chrome://')) return;
+
   // Update storage with new state for the active tab
   await chrome.storage.local.set({
     isInspectorModeEnabled: toggleInspector.checked,

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -183,6 +183,19 @@
     if (highlight) highlight.style.display = 'none';
   }
 
+  /** Removes all elements from the DOM and resets variables to null */
+  function removeElements() {
+    // Remove all elements
+    if (overlayContainer) overlayContainer.remove();
+    if (overlay) overlay.remove();
+    if (highlight) highlight.remove();
+
+    // Reset variables to null
+    overlayContainer = null;
+    overlay = null;
+    highlight = null;
+  }
+
   /** Removes event listeners */
   function removeEventListeners() {
     document.removeEventListener('mouseover', mouseOverHandler);
@@ -206,6 +219,7 @@
   chrome.runtime.onConnect.addListener(connectionPort => {
     connectionPort.onDisconnect.addListener(() => {
       removeEventListeners();
+      removeElements();
     });
   });
 })();

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -44,17 +44,11 @@
 
   /**
    * Retrieves the inspector mode state from chrome storage.
-   * @returns {boolean} The inspector mode state from chrome storage
+   * @returns {Promise<boolean>} The inspector mode state from chrome storage
    */
   async function getInspectorModeState() {
     try {
-      // Check if the chrome storage API is available
-      if (!chrome || !chrome.storage) {
-        console.error(
-          'Chrome storage API is unavailable. Extension context may be invalid.'
-        );
-        return false;
-      }
+      if (!chrome || !chrome.storage) return false;
 
       // Retrieve the inspector mode state
       const data = await chrome.storage.local.get('isInspectorModeEnabled');
@@ -221,9 +215,13 @@
 
   // Remove event listeners when the connection is closed
   chrome.runtime.onConnect.addListener(connectionPort => {
-    connectionPort.onDisconnect.addListener(() => {
-      removeEventListeners();
-      removeElements();
-    });
+    if (!connectionPort) return;
+    if (connectionPort.name === 'content-connection') {
+      connectionPort.onDisconnect.addListener(() => {
+        isInspectorModeEnabled = false;
+        removeEventListeners();
+        removeElements();
+      });
+    }
   });
 })();

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -13,16 +13,20 @@
 
   /** Initializes the inspector mode state and DOM elements */
   async function init() {
-    isInspectorModeEnabled = await getInspectorModeState();
-    overlayContainer =
-      document.getElementById('bp-inspector-container') ||
-      createAndAppend('bp-inspector-container', document.body);
-    overlay =
-      document.getElementById('bp-inspector-overlay') ||
-      createAndAppend('bp-inspector-overlay', overlayContainer);
-    highlight =
-      document.getElementById('bp-element-highlight') ||
-      createAndAppend('bp-element-highlight', document.body);
+    try {
+      isInspectorModeEnabled = await getInspectorModeState();
+      overlayContainer =
+        document.getElementById('bp-inspector-container') ||
+        createAndAppend('bp-inspector-container', document.body);
+      overlay =
+        document.getElementById('bp-inspector-overlay') ||
+        createAndAppend('bp-inspector-overlay', overlayContainer);
+      highlight =
+        document.getElementById('bp-element-highlight') ||
+        createAndAppend('bp-element-highlight', document.body);
+    } catch (error) {
+      console.error('Error initializing inspector mode:', error);
+    }
   }
 
   /**

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -26,6 +26,9 @@
         createAndAppend('bp-element-highlight', document.body);
     } catch (error) {
       console.error('Error initializing inspector mode:', error);
+      // Clean up if initialization fails
+      isInspectorModeEnabled = false;
+      removeElements();
     }
   }
 


### PR DESCRIPTION
## Overview:
This PR addresses a bug in which the inspector mode remains active even after disabling the extension from the extension management page. The issue occurs because the content script (overlay.js) stays injected and active on the page.

## Changes
- Cleaned up inspector mode DOM elements after the connection is closed
- Updated checks to prevent injecting scripts in protected (restricted) pages

**Misc:**
- Removed `On/Off` badge text from extension
