### PR TITLE
Fixed Keyboard Shortcut for Toggling Borders

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Border Patrol - CSS Outliner & Debugging Tool",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Border Patrol is a browser extension that outlines every element on a webpage, helping developers and designers visualize layouts, margins, and padding instantly.",
   "permissions": ["scripting", "storage", "activeTab"],
   "host_permissions": ["<all_urls>"],
@@ -20,10 +20,10 @@
     "128": "icons/border-patrol-icon-128.png"
   },
   "commands": {
-    "_execute_action": {
+    "toggle_border_patrol": {
       "suggested_key": {
-        "default": "Ctrl+Shift+B",
-        "mac": "Command+Shift+B"
+        "default": "Alt+Shift+B",
+        "mac": "Alt+Shift+B"
       },
       "description": "Toggle Border Patrol"
     }

--- a/scripts/border.js
+++ b/scripts/border.js
@@ -91,7 +91,7 @@ chrome.runtime.sendMessage({ action: 'GET_TAB_ID' }, async response => {
 
 // Receive message to apply outline to all elements
 chrome.runtime.onMessage.addListener(async request => {
-  if (request.action === 'UPDATE_SETTINGS') {
+  if (request.action === 'UPDATE_BORDER_SETTINGS') {
     let { borderThickness, borderStyle, tabId } = request;
     const data = await chrome.storage.local.get(`isEnabled_${tabId}`);
     const isEnabled = data[`isEnabled_${tabId}`];

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -90,7 +90,7 @@ async function updateSettings() {
 
   // Send message to update border settings
   chrome.tabs.sendMessage(tab.id, {
-    action: 'UPDATE_SETTINGS',
+    action: 'UPDATE_BORDER_SETTINGS',
     tabId: tabId,
     borderThickness: borderThickness.value,
     borderStyle: borderStyle.value,


### PR DESCRIPTION
## Issue:

The keyboard shortcut (`"Ctrl+Shift+B"`) doesn't work due to a conflict with the browser's default shortcut for hiding/showing the bookmark bar. Also, since the shortcut is set in the manifest and the extension is toggled in the menu, toggling it won't actually do anything.

## Solution:

- Changed the shortcut to `"Alt+Shift+B"`
- Created a `chrome.commands.onCommand` listener in the background script to listen for pressed shortcut commands
- Added logic to enable the shortcut of the tab when pressed
