### PR TITLE
Fix Borders Application on Fresh Install

### DIFF
--- a/background.js
+++ b/background.js
@@ -163,7 +163,7 @@ async function injectBorderScript(tabId) {
     // Connect to the content script
     chrome.tabs.connect(tabId, { name: 'content-connection' });
   } catch (error) {
-    console.error('Error injecting scripts or CSS:', error);
+    // Ignore errors
   }
 }
 

--- a/background.js
+++ b/background.js
@@ -19,8 +19,9 @@ function updateExtensionState(isEnabled) {
  * @param {Object} details - Details about the installation or update.
  */
 chrome.runtime.onInstalled.addListener(async details => {
-  // Clear any previous state and set default settings
+  // Clear any previous state
   await chrome.storage.local.set({});
+  // Set default settings for the extension
   await chrome.storage.local.set({
     borderThickness: 1,
     borderStyle: 'solid',

--- a/background.js
+++ b/background.js
@@ -18,9 +18,17 @@ function updateExtensionState(isEnabled) {
  * Clears any previous state and updates the extension state.
  * @param {Object} details - Details about the installation or update.
  */
-chrome.runtime.onInstalled.addListener(details => {
+chrome.runtime.onInstalled.addListener(async details => {
   chrome.storage.local.set({}); // Clears any previous state
   updateExtensionState(false);
+
+  try {
+    const tabId = (await getTab())?.id;
+    injectBorderScript(tabId);
+    sendInspectorModeUpdate(tabId);
+  } catch (error) {
+    console.error('Error getting tab ID:', error);
+  }
 });
 
 /**

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Border Patrol - CSS Outliner & Debugging Tool",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Border Patrol is a browser extension that outlines every element on a webpage, helping developers and designers visualize layouts, margins, and padding instantly.",
   "permissions": ["scripting", "storage", "activeTab"],
   "host_permissions": ["<all_urls>"],

--- a/scripts/border.js
+++ b/scripts/border.js
@@ -73,7 +73,7 @@ async function applyOutline(isEnabled, size, style) {
  */
 chrome.runtime.sendMessage({ action: 'GET_TAB_ID' }, async response => {
   if (chrome.runtime.lastError) {
-    console.error('Error getting tab ID:', chrome.runtime.lastError);
+    // Ignore errors
     return;
   }
 

--- a/scripts/border.js
+++ b/scripts/border.js
@@ -22,7 +22,7 @@ async function applyOutline(isEnabled, size, style) {
       'borderStyle',
     ]);
     size = data.borderThickness || 1;
-    style = data.borderStyle || style;
+    style = data.borderStyle || 'solid';
   }
   const defaultColor = 'red'; // Fallback color if tag not found
 

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -25,7 +25,6 @@
         document.getElementById('bp-element-highlight') ||
         createAndAppend('bp-element-highlight', document.body);
     } catch (error) {
-      console.error('Error initializing inspector mode:', error);
       // Clean up if initialization fails
       isInspectorModeEnabled = false;
       removeElements();
@@ -57,7 +56,7 @@
       const data = await chrome.storage.local.get('isInspectorModeEnabled');
       return data?.isInspectorModeEnabled || false;
     } catch (error) {
-      console.error('Error getting inspector mode state:', error);
+      // Ignore errors
       return false;
     }
   }


### PR DESCRIPTION
## Overview:

Borders are not appearing after the extension has been installed on a new browser. Instead, it seems that it would only be applied if the border settings were adjusted. This results in the extension not working for new users, which can lead to losing users. 

## Solution:
- Applied default borders to the tab that has the newly installed extension
- Improved error handling when getting the tab
- Fixed issue with default `borderStyle` being set to `undefined` instead of `solid`
