### PR TITLE
Update Inspect Mode to be Enabled Per-Tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -165,7 +165,19 @@ chrome.action.onClicked.addListener(async tab => {
 
 // Handles recieving messages from content scripts
 chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
-  if (!sender.tab) return;
+  console.log('Received message from content script:', request, sender);
+
+  // Check if the sender has a tab ID (possibly from popup)
+  if (!sender?.tab?.id) {
+    // Handle message from popup (sender.tab.id is undefined)
+    if (request.action === 'UPDATE_ICON') {
+      updateExtensionState(request.isEnabled);
+    }
+    return;
+  }
+
+  if (!sender?.tab?.url || isRestrictedUrl(sender?.tab?.url)) return;
+
   const tabId = sender.tab.id;
 
   // Receive message to retrieve tab ID
@@ -178,11 +190,13 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
   }
   // Recieve message to get border mode state
   if (request.action === 'GET_BORDER_MODE') {
-    sendResponse(await getTabState({ tabId, key: 'borderMode' }));
+    const state = await getTabState({ tabId, key: 'borderMode' });
+    sendResponse(state);
   }
   // Recieve message to get inspector mode state
   if (request.action === 'GET_INSPECTOR_MODE') {
-    sendResponse(await getTabState({ tabId, key: 'inspectorMode' }));
+    const state = await getTabState({ tabId, key: 'inspectorMode' });
+    sendResponse(state);
   }
 });
 

--- a/background.js
+++ b/background.js
@@ -209,7 +209,7 @@ chrome.action.onClicked.addListener(async tab => {
 
 // Handles recieving messages from content scripts
 chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
-  console.log('Received message from content script:', request, sender);
+  console.log('Received message:', request, 'from sender:', sender);
 
   // Check if the sender has a tab ID (possibly from popup)
   if (!sender?.tab?.id) {
@@ -292,7 +292,6 @@ async function sendInspectorModeUpdate(tabId) {
     // Check if the tab is a valid webpage
     const tab = await chrome.tabs.get(tabId);
     if (!tab?.url || isRestrictedUrl(tab.url)) return;
-    if (!chrome || !chrome.storage) return;
 
     // Retrieve the inspector mode state
     const isEnabled = await getTabState({ tabId, key: 'inspectorMode' });
@@ -309,13 +308,14 @@ async function sendInspectorModeUpdate(tabId) {
 
 // Handles keyboard shortcut commands
 chrome.commands.onCommand.addListener(async command => {
+  console.log('Command received:', command);
+
   // Toggle the border for the active tab
   if (command === 'toggle_border_patrol') {
     const tab = await getActiveTab();
 
     // Validate if the tab is a valid webpage
-    if (!tab?.url || isRestrictedUrl(tab.url)) return;
-    if (!chrome || !chrome.storage) return;
+    if (!tabId || !tab?.url || isRestrictedUrl(tab.url)) return;
 
     const tabId = tab.id;
 

--- a/background.js
+++ b/background.js
@@ -5,7 +5,7 @@ import {
 import { isRestrictedUrl, getActiveTab } from './scripts/helpers.js';
 
 // In-memory cache for tab states
-const _tabStates = {}; // tabId -> { borderMode: boolean, inspectorMode: boolean }
+const cachedTabStates = {}; // tabId -> { borderMode: boolean, inspectorMode: boolean }
 
 /**
  * Retrieves the extension state for the specified tab ID and key.
@@ -17,11 +17,12 @@ const _tabStates = {}; // tabId -> { borderMode: boolean, inspectorMode: boolean
  */
 async function getTabState({ tabId, key }) {
   // Check if the tab ID is in cache
-  if (_tabStates[tabId]) return _tabStates[tabId]?.[key] || false;
+  if (cachedTabStates[tabId]) return cachedTabStates[tabId]?.[key] || false;
 
   try {
     // If not in cache, retrieve from storage
     const storedData = await chrome.storage.local.get(tabId.toString());
+    log('getTabState from storage', storedData);
     return storedData?.[tabId]?.[key] || false;
   } catch (error) {
     // Ignore errors
@@ -38,9 +39,9 @@ async function getTabState({ tabId, key }) {
  * @param {boolean} options.value - The value to set the state to.
  */
 function setTabState({ tabId, key, value }) {
-  _tabStates[tabId] = _tabStates[tabId] || {}; // Initialize if not present
-  _tabStates[tabId][key] = value;
-  chrome.storage.local.set({ [tabId]: _tabStates[tabId] });
+  cachedTabStates[tabId] = cachedTabStates[tabId] || {}; // Initialize if not present
+  cachedTabStates[tabId][key] = value;
+  chrome.storage.local.set({ [tabId]: cachedTabStates[tabId] });
 }
 
 /**

--- a/background.js
+++ b/background.js
@@ -27,9 +27,7 @@ async function getTabState({ tabId, key }) {
     // Retrieve state from storage if it doesn't exist in cache
     const storedData = await chrome.storage.local.get(tabIdString);
     console.log('getTabState from storage', storedData);
-    return storedData?.[tabIdString]?.[key]
-      ? storedData[tabIdString][key]
-      : false;
+    return storedData?.[tabIdString]?.[key] ?? false;
   } catch (error) {
     // Ignore errors
     console.error('Error retrieving tab state from storage:', error);
@@ -74,8 +72,9 @@ function updateExtensionState(isEnabled) {
 }
 
 /**
- * Runs when the extension is installed or updated.
+ * Executed when the extension is installed or updated.
  * Clears any previous state and initializes the extension state and default settings.
+ *
  * @param {Object} details - Details about the installation or update.
  */
 chrome.runtime.onInstalled.addListener(async details => {
@@ -87,21 +86,8 @@ chrome.runtime.onInstalled.addListener(async details => {
     borderSize: DEFAULT_BORDER_SIZE,
     borderStyle: DEFAULT_BORDER_STYLE,
   });
+
   updateExtensionState(false);
-
-  try {
-    const tab = await getActiveTab();
-    if (!tab?.url || isRestrictedUrl(tab.url) || !tab.id) return;
-
-    const tabId = tab.id;
-
-    // Initialize the extension state for the active tab to false after installation
-    await chrome.storage.local.set({ [`isBorderEnabled_${tabId}`]: false });
-
-    injectScripts(tabId);
-  } catch (error) {
-    console.error('Error initializing extension:', error);
-  }
 });
 
 /**

--- a/manifest.json
+++ b/manifest.json
@@ -27,17 +27,5 @@
       },
       "description": "Toggle Border Patrol"
     }
-  },
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "exclude_matches": [
-        "https://chrome.google.com/webstore*",
-        "https://chromewebstore.google.com/*"
-      ],
-      "css": ["css/overlay.css"],
-      "js": ["scripts/border.js", "scripts/overlay.js"],
-      "run_at": "document_end"
-    }
-  ]
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Border Patrol - CSS Outliner & Debugging Tool",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Border Patrol is a browser extension that outlines every element on a webpage, helping developers and designers visualize layouts, margins, and padding instantly.",
   "permissions": ["scripting", "storage", "activeTab"],
   "host_permissions": ["<all_urls>"],

--- a/scripts/border.js
+++ b/scripts/border.js
@@ -76,12 +76,12 @@ chrome.runtime.sendMessage({ action: 'GET_TAB_ID' }, async response => {
 
   const tabId = response.tabId;
   const data = await chrome.storage.local.get([
-    `isEnabled_${tabId}`,
+    `isBorderEnabled_${tabId}`,
     'borderSize',
     'borderStyle',
   ]);
   const { borderSize, borderStyle } = data;
-  const isEnabled = data[`isEnabled_${tabId}`];
+  const isEnabled = data[`isBorderEnabled_${tabId}`];
 
   applyOutline(isEnabled, borderSize, borderStyle);
 });
@@ -90,8 +90,8 @@ chrome.runtime.sendMessage({ action: 'GET_TAB_ID' }, async response => {
 chrome.runtime.onMessage.addListener(async request => {
   if (request.action === 'UPDATE_BORDER_SETTINGS') {
     let { borderSize, borderStyle, tabId } = request;
-    const data = await chrome.storage.local.get(`isEnabled_${tabId}`);
-    const isEnabled = data[`isEnabled_${tabId}`];
+    const data = await chrome.storage.local.get(`isBorderEnabled_${tabId}`);
+    const isEnabled = data[`isBorderEnabled_${tabId}`];
 
     applyOutline(isEnabled, borderSize, borderStyle);
   }

--- a/scripts/border.js
+++ b/scripts/border.js
@@ -69,10 +69,7 @@ async function applyOutline(isEnabled, size, style) {
  * if the extension is enabled, otherwise removes the outline.
  */
 chrome.runtime.sendMessage({ action: 'GET_TAB_ID' }, async response => {
-  if (chrome.runtime.lastError) {
-    // Ignore errors
-    return;
-  }
+  if (chrome.runtime.lastError) return;
 
   const tabId = response;
   const tabIdString = tabId.toString();

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,2 +1,3 @@
 export const DEFAULT_BORDER_SIZE = 1;
 export const DEFAULT_BORDER_STYLE = 'solid';
+export const DEFAULT_TAB_STATE = { borderMode: false, inspectorMode: false };

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1,5 +1,6 @@
 /**
  * Checks if the provided URL is a restricted URL.
+ *
  * @param {string} url - The URL to check.
  * @returns {boolean} True if the URL is restricted, false otherwise.
  */
@@ -20,16 +21,16 @@ export function isRestrictedUrl(url) {
 }
 
 /**
- * Retrieves the active tab.
+ * Retrieves the active tab object.
+ *
  * @returns {Promise<Object>} The active tab object, or an empty object if not found.
  */
 export async function getActiveTab() {
   try {
     const queryOptions = { active: true, lastFocusedWindow: true };
     const [tab] = await chrome.tabs.query(queryOptions);
-    if (!tab) {
-      return {};
-    }
+    if (!tab) return {};
+
     return tab;
   } catch (error) {
     console.error('Error retrieving active tab:', error);

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -87,6 +87,9 @@ async function toggleInspectorMode() {
     [tabIdString]: { ...storedState[tabIdString], inspectorMode: newState },
   });
 
+  // Send message to update extension state
+  chrome.runtime.sendMessage({ action: 'UPDATE_ICON', isEnabled: newState });
+
   // Send message to update inspector mode
   chrome.tabs.sendMessage(tab.id, {
     action: 'UPDATE_INSPECTOR_MODE',

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -10,14 +10,14 @@ async function initializeStates() {
 
   const tabId = tab.id;
   const data = await chrome.storage.local.get([
-    `isEnabled_${tabId}`,
+    `isBorderEnabled_${tabId}`,
     'isInspectorModeEnabled',
     'borderSize',
     'borderStyle',
   ]);
 
   // Set the toggle switch state
-  toggleBorders.checked = data[`isEnabled_${tabId}`] || false;
+  toggleBorders.checked = data[`isBorderEnabled_${tabId}`] || false;
   toggleInspector.checked = data.isInspectorModeEnabled || false;
 
   // Set the border settings
@@ -35,14 +35,15 @@ async function initializeStates() {
 async function toggleExtension() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tab) return;
+  if (!tab?.url || tab.url.startsWith('chrome://')) return;
 
   const tabId = tab.id;
-  const data = await chrome.storage.local.get(`isEnabled_${tabId}`);
-  const isEnabled = data[`isEnabled_${tabId}`] || false;
+  const data = await chrome.storage.local.get(`isBorderEnabled_${tabId}`);
+  const isEnabled = data[`isBorderEnabled_${tabId}`] || false;
   const newState = !isEnabled;
 
   // Update storage with new state for the active tab
-  await chrome.storage.local.set({ [`isEnabled_${tabId}`]: newState });
+  await chrome.storage.local.set({ [`isBorderEnabled_${tabId}`]: newState });
 
   // Update UI toggle
   toggleBorders.checked = newState;

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -55,14 +55,14 @@ async function toggleBorderMode() {
     [tabIdString]: { ...storedState[tabIdString], borderMode: newState },
   });
 
-  // Send message to update extension state
-  chrome.runtime.sendMessage({ action: 'UPDATE_ICON', isEnabled: newState });
-
   // Send message to update border mode
   chrome.tabs.sendMessage(tab.id, {
     action: 'UPDATE_BORDER_MODE',
     isEnabled: newState,
   });
+
+  // Send message to update extension state
+  chrome.runtime.sendMessage({ action: 'UPDATE_ICON', tabId });
 }
 
 /** Toggles the inspector mode state and applies changes to the active tab. */
@@ -87,14 +87,14 @@ async function toggleInspectorMode() {
     [tabIdString]: { ...storedState[tabIdString], inspectorMode: newState },
   });
 
-  // Send message to update extension state
-  chrome.runtime.sendMessage({ action: 'UPDATE_ICON', isEnabled: newState });
-
   // Send message to update inspector mode
   chrome.tabs.sendMessage(tab.id, {
     action: 'UPDATE_INSPECTOR_MODE',
     isEnabled: toggleInspector.checked,
   });
+
+  // Send message to update extension state
+  chrome.runtime.sendMessage({ action: 'UPDATE_ICON', tabId });
 }
 
 /** Updates the border settings and applies changes to the active tab. */

--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -9,20 +9,22 @@ async function initializeStates() {
   if (!tab) return;
 
   const tabId = tab.id;
+  const tabIdString = tabId.toString();
+
+  // Get state from storage
   const data = await chrome.storage.local.get([
-    `isBorderEnabled_${tabId}`,
-    'isInspectorModeEnabled',
+    tabIdString,
     'borderSize',
     'borderStyle',
   ]);
 
   // Set the toggle switch state
-  toggleBorders.checked = data[`isBorderEnabled_${tabId}`] || false;
-  toggleInspector.checked = data.isInspectorModeEnabled || false;
+  toggleBorders.checked = data[tabIdString]?.borderMode ?? false;
+  toggleInspector.checked = data[tabIdString]?.inspectorMode ?? false;
 
   // Set the border settings
-  borderSize.value = data.borderSize || 1;
-  borderStyle.value = data.borderStyle || 'solid';
+  borderSize.value = data.borderSize ?? 1;
+  borderStyle.value = data.borderStyle ?? 'solid';
 
   // Apply changes to the active tab
   chrome.scripting.executeScript({
@@ -31,30 +33,35 @@ async function initializeStates() {
   });
 }
 
-/** Toggles the extension state and applies changes to the active tab. */
-async function toggleExtension() {
+/** Toggles the border mode state and applies changes to the active tab. */
+async function toggleBorderMode() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tab) return;
   if (!tab?.url || tab.url.startsWith('chrome://')) return;
 
   const tabId = tab.id;
-  const data = await chrome.storage.local.get(`isBorderEnabled_${tabId}`);
-  const isEnabled = data[`isBorderEnabled_${tabId}`] || false;
-  const newState = !isEnabled;
+  const tabIdString = tabId.toString();
 
-  // Update storage with new state for the active tab
-  await chrome.storage.local.set({ [`isBorderEnabled_${tabId}`]: newState });
+  // Get state from storage
+  const storedState = await chrome.storage.local.get(tabIdString);
+  const isEnabled = storedState?.[tabIdString]?.borderMode ?? false;
+  const newState = !isEnabled;
 
   // Update UI toggle
   toggleBorders.checked = newState;
 
-  // Send message to update extension icon
+  // Update storage with new state for the active tab
+  await chrome.storage.local.set({
+    [tabIdString]: { ...storedState[tabIdString], borderMode: newState },
+  });
+
+  // Send message to update extension state
   chrome.runtime.sendMessage({ action: 'UPDATE_ICON', isEnabled: newState });
 
-  // Apply changes to the active tab
-  chrome.scripting.executeScript({
-    target: { tabId: tabId },
-    files: ['scripts/border.js'],
+  // Send message to update border mode
+  chrome.tabs.sendMessage(tab.id, {
+    action: 'UPDATE_BORDER_MODE',
+    isEnabled: newState,
   });
 }
 
@@ -62,12 +69,22 @@ async function toggleExtension() {
 async function toggleInspectorMode() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tab) return;
-
   if (!tab?.url || tab.url.startsWith('chrome://')) return;
+
+  const tabId = tab.id;
+  const tabIdString = tabId.toString();
+
+  // Get state from storage
+  const storedState = await chrome.storage.local.get(tabIdString);
+  const isEnabled = storedState?.[tabIdString]?.inspectorMode ?? false;
+  const newState = !isEnabled;
+
+  // Update UI toggle
+  toggleInspector.checked = newState;
 
   // Update storage with new state for the active tab
   await chrome.storage.local.set({
-    isInspectorModeEnabled: toggleInspector.checked,
+    [tabIdString]: { ...storedState[tabIdString], inspectorMode: newState },
   });
 
   // Send message to update inspector mode
@@ -77,8 +94,8 @@ async function toggleInspectorMode() {
   });
 }
 
-/** Updates the border settings in storage. */
-async function updateSettings() {
+/** Updates the border settings and applies changes to the active tab. */
+async function updateBorderSettings() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (!tab) return;
 
@@ -102,7 +119,7 @@ async function updateSettings() {
 document.addEventListener('DOMContentLoaded', initializeStates);
 
 // Event listeners for border settings changes
-toggleBorders.addEventListener('click', toggleExtension);
+toggleBorders.addEventListener('click', toggleBorderMode);
 toggleInspector.addEventListener('change', toggleInspectorMode);
-borderSize.addEventListener('input', updateSettings);
-borderStyle.addEventListener('change', updateSettings);
+borderSize.addEventListener('input', updateBorderSettings);
+borderStyle.addEventListener('change', updateBorderSettings);

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -17,6 +17,7 @@
     try {
       // Retrieve the inspector mode state
       isInspectorModeEnabled = await getInspectorModeState();
+      console.log('IS INSPECTOR MODE ENABLED:', isInspectorModeEnabled);
 
       // Check if overlay is already initialized
       if (document.getElementById('bp-inspector-container')) {
@@ -75,10 +76,17 @@
       if (!chrome || !chrome.storage) return false;
 
       // Retrieve the inspector mode state
-      const isEnabled = await chrome.runtime.sendMessage({
-        action: 'GET_INSPECTOR_MODE',
-      });
-      console.log('IS INSPECTOR MODE ENABLED:', isEnabled);
+      await chrome.runtime.sendMessage(
+        { action: 'GET_INSPECTOR_MODE' },
+        response => {
+          isInspectorModeEnabled = response;
+        }
+      );
+
+      console.log(
+        'IS INSPECTOR MODE ENABLED:',
+        isEnisInspectorModeEnabledabled
+      );
       return isEnabled;
     } catch (error) {
       // Ignore errors

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -51,10 +51,14 @@
   async function getInspectorModeState() {
     try {
       if (!chrome || !chrome.storage) return false;
-
+      const isEnabled = await chrome.runtime.sendMessage({
+        action: 'GET_INSPECTOR_MODE',
+      });
+      console.log('IS INSPECTOR MODE ENABLED:', isEnabled);
+      return isEnabled;
       // Retrieve the inspector mode state
-      const data = await chrome.storage.local.get('isInspectorModeEnabled');
-      return data?.isInspectorModeEnabled || false;
+      // const data = await chrome.storage.local.get('isInspectorModeEnabled');
+      // return data?.isInspectorModeEnabled || false;
     } catch (error) {
       // Ignore errors
       return false;
@@ -216,6 +220,10 @@
   // Recieve message to update inspector mode
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.action === 'UPDATE_INSPECTOR_MODE') {
+      console.log(
+        'Received message to update inspector mode:',
+        request.isEnabled
+      );
       isInspectorModeEnabled = request.isEnabled;
     }
   });

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -46,19 +46,19 @@
 
   /**
    * Retrieves the inspector mode state from chrome storage.
+   *
    * @returns {Promise<boolean>} The inspector mode state from chrome storage
    */
   async function getInspectorModeState() {
     try {
       if (!chrome || !chrome.storage) return false;
+
+      // Retrieve the inspector mode state
       const isEnabled = await chrome.runtime.sendMessage({
         action: 'GET_INSPECTOR_MODE',
       });
       console.log('IS INSPECTOR MODE ENABLED:', isEnabled);
       return isEnabled;
-      // Retrieve the inspector mode state
-      // const data = await chrome.storage.local.get('isInspectorModeEnabled');
-      // return data?.isInspectorModeEnabled || false;
     } catch (error) {
       // Ignore errors
       return false;

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -13,8 +13,18 @@
 
   /** Initializes the inspector mode state and DOM elements */
   async function init() {
+    console.log('Initializing inspector mode...');
     try {
+      // Retrieve the inspector mode state
       isInspectorModeEnabled = await getInspectorModeState();
+
+      // Check if overlay is already initialized
+      if (document.getElementById('bp-inspector-container')) {
+        console.log('Overlay already initialized.');
+        return;
+      }
+
+      // Initialize DOM elements
       overlayContainer =
         document.getElementById('bp-inspector-container') ||
         createAndAppend('bp-inspector-container', document.body);
@@ -24,11 +34,22 @@
       highlight =
         document.getElementById('bp-element-highlight') ||
         createAndAppend('bp-element-highlight', document.body);
+
+      addEventListeners();
     } catch (error) {
       // Clean up if initialization fails
+      console.error('Error initializing inspector mode:', error);
       isInspectorModeEnabled = false;
       removeElements();
     }
+  }
+
+  /** Adds event listeners */
+  function addEventListeners() {
+    document.addEventListener('mouseover', mouseOverHandler);
+    document.addEventListener('mousemove', mouseMoveHandler);
+    document.addEventListener('mouseout', mouseOutHandler);
+    console.log('Overlay event listeners added.');
   }
 
   /**
@@ -211,11 +232,6 @@
     document.removeEventListener('mousemove', mouseMoveHandler);
     document.removeEventListener('mouseout', mouseOutHandler);
   }
-
-  // Add event listeners
-  document.addEventListener('mouseover', mouseOverHandler);
-  document.addEventListener('mousemove', mouseMoveHandler);
-  document.addEventListener('mouseout', mouseOutHandler);
 
   // Recieve message to update inspector mode
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {


### PR DESCRIPTION
## Overview:

This PR updates inspector mode to be applied per-tab just like how the borders are applied. 
- Allowed inspector mode to be enabled per tab instead of globally.
- Updated cache keys to combine tabStates in a object. This allows both border/inspector modes to be managed per tab.
  - Added get/set tab state functions for centralized management.

**Misc:**
- Cleaned up and refactored relevant areas of the code.
- Removed `content_scripts` from manifest since scripts are handled from code.
- Fixed initialization errors.
