### PR TITLE
Fixed Issue with host page causing BP Overlay font size to change due it host page styles 

### DIFF
--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -168,7 +168,9 @@
     overlay.innerHTML = `
       <div class="bp-element-info">
         <strong>${element.tagName.toLowerCase()}</strong><br>
-        ${Math.round(rect.width)} x ${Math.round(rect.height)} px<br>
+        <span class="bp-info-label">Dimensions:</span> ${Math.round(
+          rect.width
+        )} x ${Math.round(rect.height)} px<br>
         ${
           computedStyle.border
             ? `<span class="bp-info-label">Border:</span> ${computedStyle.border}<br>`

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -169,9 +169,21 @@
       <div class="bp-element-info">
         <strong>${element.tagName.toLowerCase()}</strong><br>
         ${Math.round(rect.width)} x ${Math.round(rect.height)} px<br>
-        ${computedStyle.border ? `Border: ${computedStyle.border}<br>` : ''}
-        ${computedStyle.margin ? `Margin: ${computedStyle.margin}<br>` : ''}
-        ${computedStyle.padding ? `Padding: ${computedStyle.padding}` : ''}
+        ${
+          computedStyle.border
+            ? `<span class="bp-info-label">Border:</span> ${computedStyle.border}<br>`
+            : ''
+        }
+        ${
+          computedStyle.margin
+            ? `<span class="bp-info-label">Margin:</span> ${computedStyle.margin}<br>`
+            : ''
+        }
+        ${
+          computedStyle.padding
+            ? `<span class="bp-info-label">Padding:</span> ${computedStyle.padding}`
+            : ''
+        }
       </div>
       <footer class="bp-branding-info">
         <span class="bp-branding">Border Patrol</span>

--- a/styles/overlay.css
+++ b/styles/overlay.css
@@ -30,9 +30,9 @@
   all: unset;
 
   position: absolute;
-  background: rgba(0, 0, 0, 0.75);
+  background: rgba(0, 0, 0, 0.8);
   color: var(--bp-blue-50);
-  padding: 5px 10px;
+  padding: 6px 10px;
   font-family: 'Inter', sans-serif;
   font-size: 12px;
   border-radius: 5px;
@@ -41,18 +41,19 @@
   max-width: 250px;
   min-width: 150px;
   line-height: 1.4;
+  box-sizing: border-box;
 }
 
 .bp-element-info {
   font-size: 12px;
-  margin-bottom: 2px;
+  margin-bottom: 4px;
 }
 
 .bp-branding-info {
   font-size: 10px;
   color: var(--bp-blue-400);
   border-top: 1px dashed var(--bp-blue-50);
-  padding-top: 2px;
+  padding-top: 4px;
   margin-top: 4px;
   text-align: right;
 }

--- a/styles/overlay.css
+++ b/styles/overlay.css
@@ -49,6 +49,12 @@
   margin-bottom: 4px;
 }
 
+.bp-element-info .bp-info-label {
+  font-weight: normal;
+  color: var(--bp-gray);
+  margin-right: 4px;
+}
+
 .bp-branding-info {
   font-size: 10px;
   color: var(--bp-blue-400);

--- a/styles/overlay.css
+++ b/styles/overlay.css
@@ -27,6 +27,8 @@
 }
 
 #bp-inspector-overlay {
+  all: unset;
+
   position: absolute;
   background: rgba(0, 0, 0, 0.75);
   color: var(--bp-blue-50);
@@ -38,19 +40,20 @@
   z-index: 9999;
   max-width: 250px;
   min-width: 150px;
+  line-height: 1.4;
 }
 
 .bp-element-info {
-  font-size: 0.7rem;
-  margin-bottom: 0.1rem;
+  font-size: 12px;
+  margin-bottom: 2px;
 }
 
 .bp-branding-info {
-  font-size: 0.6rem;
+  font-size: 10px;
   color: var(--bp-blue-400);
   border-top: 1px dashed var(--bp-blue-50);
-  padding-top: 0.1rem;
-  margin-top: 0.2rem;
+  padding-top: 2px;
+  margin-top: 4px;
   text-align: right;
 }
 


### PR DESCRIPTION
## Overview:

Fixed issues with hostpage indirectly changing the font size of the text in the overlay div. 

This happened because border patrol's inspector mode was inject in a page that change the font size of the html element 
```css
html { font-size: 56.25%; }
```
_If the browser's default font size is typically `16px`, then `56.25%` of `16px` is `9px`._

So to fix this, I did the following:
- Changed all `rem` usages to use the equivalent `px` value.
- Added `all: unset` for added isolation.

### Extras:
- Slightly increased some sizes for improved visibility.
- Added a visual distinction between the labels and their values
