### PR TITLE
Added element ID and Classes to the inspector overlay

### DIFF
--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -11,7 +11,7 @@
 
   // Logger for debugging (copied lightweight logger from helpers.js)
   const Logger = {
-    isDebug: false,
+    isDebug: true,
     info(...args) {
       if (this.isDebug) console.log('[BORDER PATROL]', ...args);
     },
@@ -164,10 +164,22 @@
     overlayContainer.style.width = `${bodyRect.width}px`;
     overlayContainer.style.height = `${bodyRect.height}px`;
 
+    console.log('Element:', element, 'Style:', computedStyle);
+    console.log('Element Class:', element.className);
+
+    const elementId = element.id ? `#${element.id}` : '';
+    const elementClass = element.className
+      ? `.${element.className.split(' ').join('.')}`
+      : '';
+
+    console.log(elementId, elementClass);
+
     // Update the overlay content with the element details
     overlay.innerHTML = `
       <div class="bp-element-info">
-        <strong>${element.tagName.toLowerCase()}</strong><br>
+        <strong>${element.tagName.toLowerCase()}</strong> <span class="bp-id-value">
+          ${elementId}
+        </span><br>
         <span class="bp-info-label">Dimensions:</span> ${Math.round(
           rect.width
         )} x ${Math.round(rect.height)} px<br>

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -180,7 +180,6 @@
           elementClasses.substring(0, MAX_CLASS_DISPLAY_LENGTH - 3) + '...';
       }
     }
-    Logger.info('Classes:', elementClasses);
 
     // Update the overlay content with the element details
     overlay.innerHTML = `
@@ -188,6 +187,11 @@
         <strong>${element.tagName.toLowerCase()}</strong> <span class="bp-id-value">
           ${elementId}
         </span><br>
+        ${
+          elementClasses
+            ? `<span class="bp-info-label">Classes:</span> ${elementClasses}<br>`
+            : ''
+        }
         <span class="bp-info-label">Dimensions:</span> ${Math.round(
           rect.width
         )} x ${Math.round(rect.height)} px<br>

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -195,6 +195,7 @@
         <span class="bp-info-label">Dimensions:</span> ${Math.round(
           rect.width
         )} x ${Math.round(rect.height)} px<br>
+        <span class="bp-info-label">Display:</span> ${computedStyle.display}<br>
         ${
           computedStyle.border
             ? `<span class="bp-info-label">Border:</span> ${computedStyle.border}<br>`

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -168,18 +168,7 @@
     Logger.info('Element:', element, 'Style:', computedStyle);
 
     const elementId = element.id ? `#${element.id}` : '';
-
-    // Get the class names of the element. Split by space and filter out empty strings
-    const classNames = element.className.split(/\s+/).filter(Boolean);
-    let elementClasses = '';
-    if (classNames.length > 0) {
-      elementClasses = `.${classNames.join(' .')}`;
-      if (elementClasses.length > MAX_CLASS_DISPLAY_LENGTH) {
-        // Limit the number of class names displayed
-        elementClasses =
-          elementClasses.substring(0, MAX_CLASS_DISPLAY_LENGTH - 3) + '...';
-      }
-    }
+    const elementClasses = getElementClassNames(element);
 
     // Update the overlay content with the element details
     overlay.innerHTML = `
@@ -240,6 +229,26 @@
         Logger.error('Error displaying highlight:', error);
       }
     });
+  }
+
+  /**
+   * Retrieves and formats the class names of an element.
+   * Truncates the list if it exceeds the maximum display length.
+   *
+   * @param {HTMLElement} element - The DOM element whose class names are to be retrieved.
+   * @returns {string} A formatted string of class names.
+   */
+  function getElementClassNames(element) {
+    const classNames = element.className.split(/\s+/).filter(Boolean);
+    let elementClasses = '';
+    if (classNames.length > 0) {
+      elementClasses = `.${classNames.join(' .')}`;
+      if (elementClasses.length > MAX_CLASS_DISPLAY_LENGTH) {
+        elementClasses =
+          elementClasses.substring(0, MAX_CLASS_DISPLAY_LENGTH - 3) + '...';
+      }
+    }
+    return elementClasses;
   }
 
   /**

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -165,14 +165,20 @@
     overlayContainer.style.height = `${bodyRect.height}px`;
 
     console.log('Element:', element, 'Style:', computedStyle);
-    console.log('Element Class:', element.className);
 
     const elementId = element.id ? `#${element.id}` : '';
-    const elementClass = element.className
-      ? `.${element.className.split(' ').join('.')}`
-      : '';
 
-    console.log(elementId, elementClass);
+    const MAX_CLASS_DISPLAY_LENGTH = 50; // Maximum length of class names to display
+
+    // Get the class names of the element. Split by space and filter out empty strings
+    const classNames = element.className.split(/\s+/).filter(Boolean);
+    let elementClasses = '';
+    if (classNames.length > 0) {
+      // Limit the number of class names displayed
+      const limitedClassNames = classNames.slice(0, MAX_CLASS_DISPLAY_LENGTH);
+      elementClasses = `.${limitedClassNames.join(' .')}...`;
+    }
+    console.log('Classes:', elementClasses);
 
     // Update the overlay content with the element details
     overlay.innerHTML = `

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -8,6 +8,7 @@
   let highlight = null;
 
   const THROTTLE_DELAY = 16; // Delay in milliseconds (16ms = 60fps)
+  const MAX_CLASS_DISPLAY_LENGTH = 50; // Maximum length of class names to display
 
   // Logger for debugging (copied lightweight logger from helpers.js)
   const Logger = {
@@ -164,21 +165,22 @@
     overlayContainer.style.width = `${bodyRect.width}px`;
     overlayContainer.style.height = `${bodyRect.height}px`;
 
-    console.log('Element:', element, 'Style:', computedStyle);
+    Logger.info('Element:', element, 'Style:', computedStyle);
 
     const elementId = element.id ? `#${element.id}` : '';
-
-    const MAX_CLASS_DISPLAY_LENGTH = 50; // Maximum length of class names to display
 
     // Get the class names of the element. Split by space and filter out empty strings
     const classNames = element.className.split(/\s+/).filter(Boolean);
     let elementClasses = '';
     if (classNames.length > 0) {
-      // Limit the number of class names displayed
-      const limitedClassNames = classNames.slice(0, MAX_CLASS_DISPLAY_LENGTH);
-      elementClasses = `.${limitedClassNames.join(' .')}...`;
+      elementClasses = `.${classNames.join(' .')}`;
+      if (elementClasses.length > MAX_CLASS_DISPLAY_LENGTH) {
+        // Limit the number of class names displayed
+        elementClasses =
+          elementClasses.substring(0, MAX_CLASS_DISPLAY_LENGTH - 3) + '...';
+      }
     }
-    console.log('Classes:', elementClasses);
+    Logger.info('Classes:', elementClasses);
 
     // Update the overlay content with the element details
     overlay.innerHTML = `

--- a/styles/overlay.css
+++ b/styles/overlay.css
@@ -1,7 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 
 :root {
-  --bp-blue: #2374ab;
   --bp-light-gray: #ccc;
   --bp-gray: #999;
   --bp-dark-gray: #333;
@@ -11,6 +10,12 @@
   --bp-blue-200: #c5e0f2;
   --bp-blue-300: #92c7e7;
   --bp-blue-400: #57a9d9;
+  --bp-blue-500: #328ec5;
+  --bp-blue-600: #2374ab; /* Main Color */
+  --bp-blue-700: #1d5a87;
+  --bp-blue-800: #1c4e70;
+  --bp-blue-900: #1c425e;
+  --bp-blue-950: #132a3e;
 
   --bp-blush-600: #aa4465;
   --bp-blush-700: #9d3957;
@@ -30,7 +35,7 @@
   all: unset;
 
   position: absolute;
-  background: rgba(0, 0, 0, 0.8);
+  background: rgba(0, 0, 0, 0.85);
   color: var(--bp-blue-50);
   padding: 6px 10px;
   font-family: 'Inter', sans-serif;
@@ -45,8 +50,14 @@
 }
 
 .bp-element-info {
+  font-weight: normal;
   font-size: 12px;
   margin-bottom: 4px;
+}
+
+.bp-element-info .bp-id-value {
+  font-weight: 500;
+  color: var(--bp-blue-300);
 }
 
 .bp-element-info .bp-info-label {


### PR DESCRIPTION
## Overview:

This PR enhances the overlay by added the id and classes of the selected element to the inspector overlay.
- Added `Id` beside the element name
- Added `Classes` to list all class selectors added on the element

**Extras:**
- Added `Display` to the overlay
- Added full BP Blue colour palette to the overlay styles

