### PR TITLE
Fixed: TypeError: element.className.split is not a function

### DIFF
--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -167,6 +167,7 @@
 
     Logger.info('Element:', element, 'Style:', computedStyle);
 
+    // Get element ID and classes
     const elementId = element.id ? `#${element.id}` : '';
     const elementClasses = getElementClassNames(element);
 
@@ -239,7 +240,11 @@
    * @returns {string} A formatted string of class names.
    */
   function getElementClassNames(element) {
-    const classNames = element.className.split(/\s+/).filter(Boolean);
+    const classAttribute = element.getAttribute('class');
+    if (!classAttribute) return '';
+
+    // Split class names by whitespace and filter out empty strings
+    const classNames = classAttribute.split(/\s+/).filter(Boolean);
     let elementClasses = '';
     if (classNames.length > 0) {
       elementClasses = `.${classNames.join(' .')}`;


### PR DESCRIPTION
## Overview:

This error was happening when using inspector mode on an SVG icon. The reference for `className` was not returning a string as the other elements due so this resulted in the following `TypeError` being thrown.

```
TypeError: element.className.split is not a function
```

## Solution:

I used the use `getAttribute('class')` function to fix this issue. This method always returns a string or null if the attribute doesn't exist, which you can then safely split().
