### PR TITLE
Fixed CSS issue with hostpage that styles default elements

### DIFF
--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -165,7 +165,7 @@
     overlayContainer.style.width = `${bodyRect.width}px`;
     overlayContainer.style.height = `${bodyRect.height}px`;
 
-    Logger.info('Element:', element, 'Style:', computedStyle);
+    // Logger.info('Element:', element, 'Style:', computedStyle);
 
     // Get element ID and classes
     const elementId = element.id ? `#${element.id}` : '';

--- a/styles/overlay.css
+++ b/styles/overlay.css
@@ -45,36 +45,45 @@
   bottom: auto;
 }
 
+/* --- Specific Styles for Core Structural Elements --- */
 #bp-inspector-container {
-  all: unset;
-
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  pointer-events: none;
-  z-index: 10000;
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 100vw !important;
+  height: 100vh !important;
+  pointer-events: none !important;
+  z-index: 10000 !important;
 }
 
 #bp-inspector-overlay {
   all: unset;
 
-  position: absolute;
-  background: rgba(0, 0, 0, 0.85);
+  position: absolute !important;
+  display: block !important;
+  box-sizing: border-box !important;
+  background: rgba(0, 0, 0, 0.85) !important;
   color: var(--bp-blue-50);
   padding: 6px 10px;
   font-family: 'Inter', sans-serif;
   font-size: 12px;
   border-radius: 5px;
-  pointer-events: none;
-  z-index: 9999;
+  pointer-events: none !important;
+  z-index: 9999 !important;
   max-width: 250px;
   min-width: 150px;
   line-height: 1.4;
-  box-sizing: border-box;
 }
 
+#bp-element-highlight {
+  position: absolute !important;
+  background-color: var(--bp-blush-600) !important;
+  opacity: 0.3 !important;
+  pointer-events: none !important;
+  z-index: 9998 !important;
+}
+
+/* --- Specific Styles for Inner Element Information --- */
 .bp-element-info {
   font-weight: normal;
   font-size: 12px;
@@ -99,12 +108,4 @@
   padding-top: 4px;
   margin-top: 4px;
   text-align: right;
-}
-
-#bp-element-highlight {
-  position: absolute;
-  background-color: var(--bp-blush-600);
-  opacity: 0.3;
-  pointer-events: none;
-  z-index: 9998;
 }

--- a/styles/overlay.css
+++ b/styles/overlay.css
@@ -21,6 +21,30 @@
   --bp-blush-700: #9d3957;
 }
 
+#bp-inspector-container,
+#bp-inspector-overlay,
+#bp-element-highlight,
+.bp-element-info,
+.bp-branding-info {
+  /* Reset these styles to prevent interference with the overlay */
+  background: none;
+  box-shadow: none;
+  border: none;
+  border-radius: 0;
+  margin: 0;
+  padding: 0;
+  width: auto;
+  height: auto;
+  min-width: unset;
+  min-height: unset;
+  max-width: unset;
+  max-height: unset;
+  top: auto;
+  left: auto;
+  right: auto;
+  bottom: auto;
+}
+
 #bp-inspector-container {
   all: unset;
 
@@ -31,14 +55,6 @@
   height: 100vh;
   pointer-events: none;
   z-index: 10000;
-
-  /* Reset these styles to prevent interference with the overlay */
-  background: none !important;
-  box-shadow: none !important;
-  border: none !important;
-  border-radius: 0 !important;
-  margin: 0 !important;
-  padding: 0 !important;
 }
 
 #bp-inspector-overlay {

--- a/styles/overlay.css
+++ b/styles/overlay.css
@@ -22,6 +22,8 @@
 }
 
 #bp-inspector-container {
+  all: unset;
+
   position: fixed;
   top: 0;
   left: 0;
@@ -29,6 +31,14 @@
   height: 100vh;
   pointer-events: none;
   z-index: 10000;
+
+  /* Reset these styles to prevent interference with the overlay */
+  background: none !important;
+  box-shadow: none !important;
+  border: none !important;
+  border-radius: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
 }
 
 #bp-inspector-overlay {


### PR DESCRIPTION
## Overview:

If the hostpage that Border Patrol injects itself in contains stles that target the default html element (especially div), they will distrupt the extension's styles. 

Bad Hostpage: https://example.com/
- This page targets the div element directly and adds sloppy styles to it 

## Solution:

- Created a multi-selector to reset many inherited styles
- Added `!important` to some of the core styles (Note: this is actually needed since the extension is injected into a host site. Since we have no control of the styles there, we must use important where needed to guarantee the extension works properly).
