### PR TITLE
Fix overlay position calculation

### DIFF
--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -124,8 +124,8 @@
     }
 
     return {
-      top: posY + window.scrollY,
-      left: posX + window.scrollX,
+      top: posY,
+      left: posX,
     };
   }
 


### PR DESCRIPTION
## Description:

The overlay was shifting when scrolling due to an incorrect coordinate system. The issue arose from adding window.scrollY and window.scrollX to the overlay's position calculations, which resulted in document coordinates being used for an absolutely positioned element with a fixed parent.

This PR fixes the issue by using viewport coordinates for the overlay's position calculations, ensuring the overlay remains correctly positioned relative to the viewport.

## Changes:

- Removed window.scrollY and window.scrollX from the overlay's position calculations in the getOverlayPosition function.
- Updated the calculation to use only viewport coordinates (event.clientY and event.clientX) to determine the overlay's position.
