### PR TITLE
Fixed: Uncaught (in promise) Error: No tab with id:

### DIFF
--- a/background.js
+++ b/background.js
@@ -270,7 +270,11 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (!tabId || !tab?.url || isRestrictedUrl(tab.url)) return;
 
   if (changeInfo.status === 'complete') {
-    await handleTabStateChange({ tabId });
+    try {
+      await handleTabStateChange({ tabId });
+    } catch (error) {
+      Logger.error(`Error in onUpdated for tab ${tabId}:`, error);
+    }
   }
 });
 
@@ -447,24 +451,34 @@ chrome.commands.onCommand.addListener(async command => {
 
   // Toggle the border for the active tab
   if (command === 'toggle_border_patrol') {
-    const tab = await getActiveTab();
+    let tabId = tab.id;
 
-    // Validate if the tab is a valid webpage
-    if (!tab?.id || !tab?.url || isRestrictedUrl(tab.url)) {
-      Logger.warn('Ignoring command on restricted or invalid tab.');
+    try {
+      // Get the active tab to determine which tab to toggle
+      const activeTab = await getActiveTab();
+      if (!activeTab?.id || !activeTab?.url || isRestrictedUrl(activeTab.url)) {
+        Logger.warn('Ignoring command on restricted or invalid tab.');
+        return;
+      }
+      tabId = activeTab.id;
+    } catch (error) {
+      Logger.error('Error getting active tab:', error);
       return;
     }
 
-    const tabId = tab.id;
+    try {
+      // Get current state
+      const currentState = await getTabState({ tabId });
+      // Toggle border mode
+      const newState = !currentState.borderMode;
 
-    // Get current state
-    const currentState = await getTabState({ tabId });
-    // Toggle border mode
-    const newState = !currentState.borderMode;
+      Logger.info(`Toggling border mode for tab ${tabId}:`, newState);
 
-    Logger.info(`Toggling border mode for tab ${tabId}:`, newState);
-
-    // Handle the state change centrally
-    await handleTabStateChange({ tabId, states: { borderMode: newState } });
+      // Handle the state change centrally
+      await handleTabStateChange({ tabId, states: { borderMode: newState } });
+    } catch (error) {
+      Logger.error(`Error toggling border mode for tab ${tabId}:`, error);
+      return;
+    }
   }
 });

--- a/background.js
+++ b/background.js
@@ -461,12 +461,7 @@ chrome.commands.onCommand.addListener(async command => {
         return;
       }
       tabId = activeTab.id;
-    } catch (error) {
-      Logger.error('Error getting active tab:', error);
-      return;
-    }
 
-    try {
       // Get current state and toggle border mode
       const currentState = await getTabState({ tabId });
       const newState = !currentState.borderMode;

--- a/background.js
+++ b/background.js
@@ -451,7 +451,7 @@ chrome.commands.onCommand.addListener(async command => {
 
   // Toggle the border for the active tab
   if (command === 'toggle_border_patrol') {
-    let tabId = tab.id;
+    let tabId;
 
     try {
       // Get the active tab to determine which tab to toggle
@@ -467,12 +467,9 @@ chrome.commands.onCommand.addListener(async command => {
     }
 
     try {
-      // Get current state
+      // Get current state and toggle border mode
       const currentState = await getTabState({ tabId });
-      // Toggle border mode
       const newState = !currentState.borderMode;
-
-      Logger.info(`Toggling border mode for tab ${tabId}:`, newState);
 
       // Handle the state change centrally
       await handleTabStateChange({ tabId, states: { borderMode: newState } });


### PR DESCRIPTION
## Overview:

This issue seems to be happening in both the `chrome.tabs.onUpdated` and `chrome.commands.onCommand`. It will happen during these scenarios. 

- The tab was closed: The user closed the tab before your extension's code finished its operation.
- The tab navigated away: The tab changed to a different URL. When this happens, the old "context" associated with the previous page and its tab ID can become invalid for injection attempts.
- Race Condition: Your extension tried to inject too quickly after a tab was created or updated, before the browser fully established the tab's context for script injection. 

**The Errors:**
```
%c[BORDER PATROL] color: #e74c3c Error injecting scripts or CSS into tab 1949043149: Error: No tab with id: 1949043149.

Uncaught (in promise) Error: No tab with id: 1949043149.

Unchecked runtime.lastError: No tab with id: 1949043149.
```

## Solution:

The Uncaught (in promise) error indicates that a JavaScript Promise was `rejected`, and there was no `.catch()` handler attached to it to deal with that rejection. So to fix it, we should add a try/catch both to the 2 top level functions mentioned above.
