### PR TITLE
Fixed: SVG and Path Elements' className can't be split

### DIFF
--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -12,7 +12,7 @@
 
   // Logger for debugging (copied lightweight logger from helpers.js)
   const Logger = {
-    isDebug: true,
+    isDebug: false,
     info(...args) {
       if (this.isDebug) console.log('[BORDER PATROL]', ...args);
     },

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -241,13 +241,11 @@
    */
   function getElementClassNames(element) {
     const classAttribute = element.getAttribute('class');
-    const classString =
-      typeof classAttribute === 'string' ? classAttribute : '';
-    // If no class attribute, return empty string
-    if (!classString) return '';
+    // Handle cases where class attribute is null or not a string
+    if (!classAttribute || typeof classAttribute !== 'string') return '';
 
     // Split class names by whitespace and filter out empty strings
-    const classNames = classString.split(/\s+/).filter(Boolean);
+    const classNames = classAttribute.split(/\s+/).filter(Boolean);
     let elementClasses = '';
     if (classNames.length > 0) {
       elementClasses = `.${classNames.join(' .')}`;

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -12,7 +12,7 @@
 
   // Logger for debugging (copied lightweight logger from helpers.js)
   const Logger = {
-    isDebug: false,
+    isDebug: true,
     info(...args) {
       if (this.isDebug) console.log('[BORDER PATROL]', ...args);
     },
@@ -241,10 +241,13 @@
    */
   function getElementClassNames(element) {
     const classAttribute = element.getAttribute('class');
-    if (!classAttribute) return '';
+    const classString =
+      typeof classAttribute === 'string' ? classAttribute : '';
+    // If no class attribute, return empty string
+    if (!classString) return '';
 
     // Split class names by whitespace and filter out empty strings
-    const classNames = classAttribute.split(/\s+/).filter(Boolean);
+    const classNames = classString.split(/\s+/).filter(Boolean);
     let elementClasses = '';
     if (classNames.length > 0) {
       elementClasses = `.${classNames.join(' .')}`;


### PR DESCRIPTION
## Overview:

This PR fixes a `TypeError` that occurs when the `getElementClassNames` function tries to call `split()` on a non-string value. 

```js
"Uncaught (in promise) TypeError: element.className.split is not a function"
```

The error is caused by SVG and Path elements not returning a string or their `className` property. This means it doesn't have a `split()` method, so it will cause and error when the method is invoked.
