### PR TITLE
Fixed: Border mode outlines injected into inspector mode overlay

### DIFF
--- a/scripts/border.js
+++ b/scripts/border.js
@@ -27,15 +27,7 @@
    * @returns {boolean} - True if the element is part of the Inspector UI, false otherwise.
    */
   function isInspectorUIElement(element) {
-    return (
-      (element.id &&
-        [
-          'bp-inspector-container',
-          'bp-inspector-overlay',
-          'bp-element-highlight',
-        ].includes(element.id)) ||
-      bpInspectorContainer?.contains(element)
-    );
+    return bpInspectorContainer?.contains(element);
   }
 
   /**
@@ -53,6 +45,10 @@
     // Remove outline if extension is disabled
     if (!isEnabled) {
       document.querySelectorAll('*').forEach(element => {
+        // Skip Border Patrol Inspector UI elements
+        if (isInspectorUIElement(element)) return;
+
+        // Remove outline from all elements
         element.style.outline = 'none';
       });
       return;

--- a/scripts/border.js
+++ b/scripts/border.js
@@ -3,6 +3,9 @@
   let isBorderModeEnabled = false;
   let currentBorderSettings = { size: 1, style: 'solid' };
 
+  // Get the Border Patrol Inspector container
+  let bpInspectorContainer = document.querySelector('#bp-inspector-container');
+
   // Logger for debugging (copied lightweight logger from helpers.js)
   const Logger = {
     isDebug: false,
@@ -25,9 +28,13 @@
    */
   function isInspectorUIElement(element) {
     return (
-      (element.id && element.id === 'bp-inspector-container') ||
-      element.id === 'bp-inspector-overlay' ||
-      element.id === 'bp-element-highlight'
+      (element.id &&
+        [
+          'bp-inspector-container',
+          'bp-inspector-overlay',
+          'bp-element-highlight',
+        ].includes(element.id)) ||
+      bpInspectorContainer?.contains(element)
     );
   }
 
@@ -77,6 +84,9 @@
         color: 'orange',
       },
     };
+
+    // Update the Border Patrol Inspector container reference
+    bpInspectorContainer = document.querySelector('#bp-inspector-container');
 
     // Apply outline to all elements
     document.querySelectorAll('*').forEach(element => {

--- a/scripts/border.js
+++ b/scripts/border.js
@@ -18,6 +18,20 @@
   };
 
   /**
+   * Checks if an element is part of the Border Patrol Inspector UI.
+   *
+   * @param {Element} element - The element to check.
+   * @returns {boolean} - True if the element is part of the Inspector UI, false otherwise.
+   */
+  function isInspectorUIElement(element) {
+    return (
+      (element.id && element.id === 'bp-inspector-container') ||
+      element.id === 'bp-inspector-overlay' ||
+      element.id === 'bp-element-highlight'
+    );
+  }
+
+  /**
    * Manages applying or removing extension-specific outlines to elements.
    *
    * @param {boolean} isEnabled - Determines whether the outline should be applied.
@@ -78,17 +92,9 @@
       }
 
       // Exclude applying outlines to Border Patrol elements
-      if (
-        element.id &&
-        [
-          'bp-inspector-container',
-          'bp-inspector-overlay',
-          'bp-element-highlight',
-        ].includes(element.id)
-      ) {
-        return;
-      }
+      if (isInspectorUIElement(element)) return;
 
+      // Apply the outline style to the element
       element.style.outline = `${size}px ${style} ${color}`;
     });
   }

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -309,14 +309,12 @@
     if (highlight) highlight.style.display = 'none';
   }
 
-  /** Removes all elements from the DOM and resets variables to null */
+  /** Removes all overlay elements from the DOM and resets related variables to null */
   function removeElements() {
-    // Remove all elements
-    if (overlayContainer) overlayContainer.remove();
-    if (overlay) overlay.remove();
-    if (highlight) highlight.remove();
+    // Remove the overlay container from the DOM if it exists
+    overlayContainer?.remove();
 
-    // Reset variables to null
+    // Reset DOM element variables to null
     overlayContainer = null;
     overlay = null;
     highlight = null;

--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -60,7 +60,7 @@
     // Initialize DOM elements
     overlayContainer = createAndAppend('bp-inspector-container', document.body);
     overlay = createAndAppend('bp-inspector-overlay', overlayContainer);
-    highlight = createAndAppend('bp-element-highlight', document.body);
+    highlight = createAndAppend('bp-element-highlight', overlayContainer);
 
     // Ensure they are hidden initially
     if (overlay) overlay.style.display = 'none';
@@ -219,8 +219,8 @@
 
       try {
         // Set position and size of the highlight
-        highlight.style.top = `${rect.top + window.scrollY}px`;
-        highlight.style.left = `${rect.left + window.scrollX}px`;
+        highlight.style.top = `${rect.top}px`;
+        highlight.style.left = `${rect.left}px`;
         highlight.style.width = `${rect.width}px`;
         highlight.style.height = `${rect.height}px`;
 


### PR DESCRIPTION
## Overview:

When Border Patrol's "Border Mode" is active, its border and outline styles are unintentionally applied to the elements within the "Inspector Overlay" modal. The borders are not needed on any inspector mode element because border mode is meant for seeing the hostpage layout not the extension's modal layout. Also, it can result in the text being hard to read due to the added visual clutter.

## Changes:

- Refactored highlight logic to be nested under the bp container, this results in all extension elements being contained in a single `div` (as it was previously attached directly to the body) which is a lot cleaner and easier to manage.
- Updated border application logic to skip all elements under the `#bp-inspector-container`
