### PR TITLE
Fixed: Border Information in Inspector Overlay Showing Even When Not Set

### DIFF
--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -130,6 +130,31 @@
   }
 
   /**
+   * Gets the formatted border information from the computed style
+   *
+   * @param {CSSStyleDeclaration} computedStyle - The computed style of the element
+   * @returns {string} The formatted border information (width style color) or an empty string if no border is present
+   */
+  function getFormattedBorderInfo(computedStyle) {
+    // Extract border information from computed style
+    const borderWidth = computedStyle.borderWidth || '0px';
+    const borderStyle = computedStyle.borderStyle || 'none';
+    const borderColor = computedStyle.borderColor || 'transparent';
+
+    // Return empty string if any of the border properties indicate no border
+    if (
+      borderWidth === '0px' ||
+      borderStyle === 'none' ||
+      borderColor === 'transparent'
+    ) {
+      return '';
+    }
+
+    // Format the border information
+    return `${borderWidth} ${borderStyle} ${borderColor}`;
+  }
+
+  /**
    * Displays the overlay on mouseover
    *
    * @param {Event} event - The triggered event
@@ -156,6 +181,9 @@
     const computedStyle = window.getComputedStyle(element);
 
     if (!rect || !computedStyle) return;
+
+    // Get the formatted border information
+    const borderInfo = getFormattedBorderInfo(computedStyle);
 
     const bodyRect = document.body.getBoundingClientRect();
 
@@ -187,8 +215,8 @@
         )} x ${Math.round(rect.height)} px<br>
         <span class="bp-info-label">Display:</span> ${computedStyle.display}<br>
         ${
-          computedStyle.border
-            ? `<span class="bp-info-label">Border:</span> ${computedStyle.border}<br>`
+          borderInfo
+            ? `<span class="bp-info-label">Border:</span> ${borderInfo}<br>`
             : ''
         }
         ${


### PR DESCRIPTION
## Description:

This PR addresses the issue of misleading "No Border" information in the Inspector Overlay. Currently, the overlay displays the computed CSS string for the border property, which can be distracting and misleading when an element has no visible border.

Example:
```
Border: 0px none rgb(255, 255, 255)
```
This PR introduces a new helper function, `getFormattedBorderInfo`, to transform the raw `computedStyle.border` string into a more user-friendly format and only display the border when it is actually visible on the UI.

### Changes:

- Added a new helper function `getFormattedBorderInfo` in `overlay.js` to handle border formatting
- Retrieved individual properties (`borderWidth`, `borderStyle`, `borderColor`) instead of relying on shorthand `computedStyle.border`
- Only display border information when it is visible on the UI
