### PR TITLE
Fixed: Allow Border Patrol to access local files

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -10,7 +10,8 @@ export function isRestrictedUrl(url) {
     'chrome-extension:',
     'about:',
     'edge:',
-    'file:',
+    'edge-extension:',
+    'moz-extension:',
   ];
 
   return (


### PR DESCRIPTION
## Overview:

Previously Border Patrol was not allowed to run on local files. However, this didn't make sense since a lot of development is done locally, therefore missing out on a huge market of users that could benefit from being able to use this.

As such, it is now available to be used for local development!!!
