### PR TITLE
Enhancement: Update Popup UI for Restricted Pages

### DIFF
--- a/background.js
+++ b/background.js
@@ -86,27 +86,43 @@ async function setTabState({ tabId, states }) {
  */
 async function updateExtensionState(tabId) {
   try {
-    const tabState = await getTabState({ tabId });
-    const isEnabled = tabState?.borderMode || tabState?.inspectorMode;
+    const tab = await chrome.tabs.get(tabId);
+    if (!tab?.url) return;
 
-    chrome.action.setTitle({
-      tabId: tabId,
-      title: isEnabled ? 'Border Patrol - Enabled' : 'Border Patrol - Disabled',
-    });
-    chrome.action.setIcon({
-      tabId: tabId,
-      path: isEnabled
-        ? 'assets/icons/bp-icon-16.png'
-        : 'assets/icons/bp-icon-16-disabled.png',
-    });
+    const isRestricted = isRestrictedUrl(tab.url);
+    const tabState = await getTabState({ tabId });
+    const isActive = tabState.borderMode || tabState.inspectorMode;
+
+    // Set the extension title
+    const title = isRestricted
+      ? 'Border Patrol - Restricted'
+      : isActive
+      ? 'Border Patrol - Active'
+      : 'Border Patrol - Inactive';
+
+    // Set the extension title
+    await chrome.action.setTitle({ title, tabId });
+
+    // Set the extension icon
+    const iconPath = isRestricted
+      ? 'assets/icons/bp-icon-16-disabled.png'
+      : isActive
+      ? 'assets/icons/bp-icon-16.png'
+      : 'assets/icons/bp-icon-16-disabled.png';
+
+    await chrome.action.setIcon({ path: iconPath, tabId });
   } catch (error) {
     Logger.error(`Error updating extension state for tab ${tabId}:`, error);
 
     // Fallback to default state
-    chrome.action.setTitle({ tabId: tabId, title: 'Border Patrol - Disabled' });
-    chrome.action.setIcon({
-      tabId: tabId,
+    await chrome.action.setTitle({
+      title: 'Border Patrol - Error',
+      tabId,
+    });
+
+    await chrome.action.setIcon({
       path: 'assets/icons/bp-icon-16-disabled.png',
+      tabId,
     });
   }
 }

--- a/background.js
+++ b/background.js
@@ -115,11 +115,7 @@ async function updateExtensionState(tabId) {
     Logger.error(`Error updating extension state for tab ${tabId}:`, error);
 
     // Fallback to default state
-    await chrome.action.setTitle({
-      title: 'Border Patrol - Error',
-      tabId,
-    });
-
+    await chrome.action.setTitle({ title: 'Border Patrol - Error', tabId });
     await chrome.action.setIcon({
       path: 'assets/icons/bp-icon-16-disabled.png',
       tabId,

--- a/popup/menu.css
+++ b/popup/menu.css
@@ -29,6 +29,30 @@
 body {
   padding: 1rem;
   width: 16rem;
+  transition: opacity 0.2s ease;
+}
+
+/* Restricted message styles */
+.restricted-message {
+  background-color: #fff3cd;
+  border-left: 4px solid #ffc107;
+  color: #856404;
+  padding: 12px;
+  margin: 12px 0;
+  border-radius: 4px;
+  display: none;
+}
+
+.restricted-message p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+/* Disabled state for form elements */
+body.restricted .form-container {
+  opacity: 0.5;
+  pointer-events: none;
 }
 
 /* Title Styles */

--- a/popup/menu.html
+++ b/popup/menu.html
@@ -20,6 +20,9 @@
 
   <body>
     <h1 id="menu-title" class="menu-title">Border Patrol</h1>
+    <div id="restricted-message" class="restricted-message">
+      <p>Border Patrol cannot be used on this page.</p>
+    </div>
 
     <hr />
 

--- a/popup/menu.js
+++ b/popup/menu.js
@@ -5,19 +5,34 @@ const toggleBorders = document.querySelector('#toggleBorders');
 const toggleInspector = document.querySelector('#toggleInspector');
 const borderSize = document.querySelector('#borderSize');
 const borderStyle = document.querySelector('#borderStyle');
+const restrictedMessage = document.querySelector('#restricted-message');
 
-/** Shows the restricted page state in the popup */
-function showRestrictedState() {
-  document.body.classList.add('restricted');
-  document.getElementById('restricted-message').style.display = 'block';
+/**
+ * Toggles the restricted page state in the popup
+ *
+ * @param {boolean} isRestricted - Whether the page is restricted or not
+ */
+function toggleRestrictedState(isRestricted) {
+  document.body.classList.toggle('restricted', isRestricted);
+  restrictedMessage?.style.display = isRestricted ? 'block' : 'none';
 
-  // Disable all form controls
+  // Toggle form controls
   const formControls = document.querySelectorAll(
     'input, select, button, fieldset'
   );
   formControls.forEach(control => {
-    control.disabled = true;
+    control.disabled = isRestricted;
   });
+}
+
+/** Shows the restricted page state in the popup */
+function showRestrictedState() {
+  toggleRestrictedState(true);
+}
+
+/** Hides the restricted page state and enables form controls */
+function hideRestrictedState() {
+  toggleRestrictedState(false);
 }
 
 /** Initializes the toggle switch state and border settings from storage. */
@@ -25,21 +40,20 @@ async function initializeStates() {
   Logger.info('Initializing popup state...');
 
   // Check if DOM elements exist before accessing
-  if (!toggleBorders || !toggleInspector || !borderSize || !borderStyle) return;
+  if (!toggleBorders || !toggleInspector || !borderSize || !borderStyle || !restrictedMessage) return;
 
   try {
     // Get the active tab and check if it's valid
     const tab = await getActiveTab();
     if (!tab?.id || !tab?.url || isRestrictedUrl(tab.url)) {
       showRestrictedState();
-      await chrome.action.setTitle({
-        title: 'Border Patrol - Restricted',
-        tabId: tab.id,
-      });
       return;
     }
 
-    const tabIdString = tab.id?.toString();
+    // Ensure restricted state is hidden if we're on a valid page
+    hideRestrictedState();
+
+    const tabIdString = tab.id.toString();
 
     // Get state from storage
     const data = await chrome.storage.local.get([
@@ -58,10 +72,6 @@ async function initializeStates() {
   } catch (error) {
     Logger.error('Error during initialization:', error);
     showRestrictedState();
-    await chrome.action.setTitle({
-      title: 'Border Patrol - Error',
-      tabId: tab.id,
-    });
     return;
   }
 }

--- a/popup/menu.js
+++ b/popup/menu.js
@@ -6,6 +6,20 @@ const toggleInspector = document.querySelector('#toggleInspector');
 const borderSize = document.querySelector('#borderSize');
 const borderStyle = document.querySelector('#borderStyle');
 
+/** Shows the restricted page state in the popup */
+function showRestrictedState() {
+  document.body.classList.add('restricted');
+  document.getElementById('restricted-message').style.display = 'block';
+
+  // Disable all form controls
+  const formControls = document.querySelectorAll(
+    'input, select, button, fieldset'
+  );
+  formControls.forEach(control => {
+    control.disabled = true;
+  });
+}
+
 /** Initializes the toggle switch state and border settings from storage. */
 async function initializeStates() {
   Logger.info('Initializing popup state...');
@@ -16,7 +30,14 @@ async function initializeStates() {
   try {
     // Get the active tab and check if it's valid
     const tab = await getActiveTab();
-    if (!tab?.id || !tab?.url || isRestrictedUrl(tab.url)) return;
+    if (!tab?.id || !tab?.url || isRestrictedUrl(tab.url)) {
+      showRestrictedState();
+      await chrome.action.setTitle({
+        title: 'Border Patrol - Restricted',
+        tabId: tab.id,
+      });
+      return;
+    }
 
     const tabIdString = tab.id?.toString();
 
@@ -36,6 +57,12 @@ async function initializeStates() {
     borderStyle.value = data.borderStyle ?? 'solid';
   } catch (error) {
     Logger.error('Error during initialization:', error);
+    showRestrictedState();
+    await chrome.action.setTitle({
+      title: 'Border Patrol - Error',
+      tabId: tab.id,
+    });
+    return;
   }
 }
 


### PR DESCRIPTION
## Overview:

This PR improves user clarity by dynamically updating the extension popup interface when Border Patrol cannot be used on certain pages (such as `chrome://` or `file://` URLs).

- Updates the extension title to clearly indicate when the extension is unavailable on a given page.
- Adds a message informing users that the extension cannot be used in restricted contexts.
- Disables user inputs in the popup when the extension is not available.

This update ensures users receive immediate and clear feedback, reducing confusion when the extension cannot operate due to browser restrictions.
