### PR TITLE
Add Screenshot Capture Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added Rollup bundler to Border Patrol to improve build process and performance.
+- Popup now includes a "Take Screenshot" button to capture and download the current tab as an image.
 
 ## [1.2.4] - 2025-06-08
 

--- a/src/background.js
+++ b/src/background.js
@@ -403,19 +403,15 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
       }
       // Handle screenshot request from popup
       else if (request.action === 'CAPTURE_SCREENSHOT') {
+        const format = 'png';
         try {
           const screenshotUrl = await chrome.tabs.captureVisibleTab(
             activeTab.windowId,
-            { format: 'png' }
+            { format }
           );
           Logger.info('Screenshot captured successfully:', screenshotUrl);
 
-          // Generate a filename based on the current timestamp
-          const timestamp = new Date()
-            .toISOString()
-            .replace(/[:]/g, '-')
-            .split('.')[0]; // Remove milliseconds
-          const filename = `border_patrol_screenshot_${timestamp}.png`;
+          const filename = getTimestampedScreenshotFilename(format);
 
           // Download the screenshot using the downloads API
           await chrome.downloads.download({

--- a/src/background.js
+++ b/src/background.js
@@ -409,8 +409,23 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
             { format: 'png' }
           );
           Logger.info('Screenshot captured successfully:', screenshotUrl);
+
+          // Generate a filename based on the current timestamp
+          const timestamp = new Date()
+            .toISOString()
+            .replace(/[:]/g, '-')
+            .split('.')[0]; // Remove milliseconds
+          const filename = `border_patrol_screenshot_${timestamp}.png`;
+
+          // Download the screenshot using the downloads API
+          await chrome.downloads.download({
+            url: screenshotUrl,
+            filename: filename,
+            saveAs: false, // Prompt user to choose location
+          });
         } catch (error) {
           Logger.error('Error capturing screenshot:', error);
+          return false; // Indicate no response
         }
         return true; // Indicate async handling
       } else {

--- a/src/background.js
+++ b/src/background.js
@@ -350,6 +350,10 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
 
       // Use the active tab's ID for processing popup messages
       const activeTabId = activeTab.id;
+      Logger.info(
+        `Handling popup message for active tab ${activeTabId}:`,
+        activeTab
+      );
 
       // Receive message to toggle border mode
       if (request.action === 'TOGGLE_BORDER_MODE') {
@@ -396,11 +400,23 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
             );
           }
         }
+      }
+      // Handle screenshot request from popup
+      else if (request.action === 'CAPTURE_SCREENSHOT') {
+        try {
+          const screenshotUrl = await chrome.tabs.captureVisibleTab(
+            activeTab.windowId,
+            { format: 'png' }
+          );
+          Logger.info('Screenshot captured successfully:', screenshotUrl);
+        } catch (error) {
+          Logger.error('Error capturing screenshot:', error);
+        }
+        return true; // Indicate async handling
       } else {
         Logger.warn('Received unknown message from popup:', request);
         return false; // No action matched
       }
-
       return true; // Indicate async handling for popup messages
     } catch (error) {
       Logger.error('Error handling popup message:', error);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "Border Patrol - CSS Outliner & Debugging Tool",
   "version": "1.3.0",
   "description": "Inspect web layout instantly! Visualize element spacing & structure. Outlines webpage elements. For developers & designers.",
-  "permissions": ["scripting", "storage", "activeTab"],
+  "permissions": ["scripting", "storage", "activeTab", "downloads"],
   "host_permissions": ["<all_urls>"],
   "action": {
     "default_title": "Border Patrol",

--- a/src/popup/menu.css
+++ b/src/popup/menu.css
@@ -129,7 +129,7 @@ a {
   padding: 0 0.5rem;
 }
 
-#screenshotButton {
+#screenshot-button {
   background-color: var(--bp-blue);
   color: var(--bp-blue-50);
   border: none;
@@ -145,18 +145,18 @@ a {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-#screenshotButton:hover {
+#screenshot-button:hover {
   background-color: var(--bp-blue-700);
   transform: translateY(-1px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
-#screenshotButton:active {
+#screenshot-button:active {
   transform: translateY(0);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-#screenshotButton:disabled {
+#screenshot-button:disabled {
   background-color: var(--bp-light-gray);
   cursor: not-allowed;
   transform: none;
@@ -165,7 +165,7 @@ a {
 }
 
 /* Add a camera icon using pseudo-element */
-#screenshotButton::before {
+#screenshot-button::before {
   content: '📸';
   font-size: 1rem;
 }

--- a/src/popup/menu.css
+++ b/src/popup/menu.css
@@ -121,6 +121,55 @@ a {
   color: var(--bp-gray);
 }
 
+/* Screenshot Section */
+.screenshot-container {
+  display: flex;
+  justify-content: center;
+  margin: 1rem 0 1rem;
+  padding: 0 0.5rem;
+}
+
+#screenshotButton {
+  background-color: var(--bp-blue);
+  color: var(--bp-blue-50);
+  border: none;
+  border-radius: 5px;
+  padding: 0.6rem 1.2rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+#screenshotButton:hover {
+  background-color: var(--bp-blue-700);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+#screenshotButton:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+#screenshotButton:disabled {
+  background-color: var(--bp-light-gray);
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+  opacity: 0.7;
+}
+
+/* Add a camera icon using pseudo-element */
+#screenshotButton::before {
+  content: '📸';
+  font-size: 1rem;
+}
+
 /* Separator */
 hr {
   margin: 0.8rem 0;

--- a/src/popup/menu.html
+++ b/src/popup/menu.html
@@ -78,6 +78,12 @@
           </select>
         </div>
       </fieldset>
+
+      <!-- Screenshot -->
+      <div class="screenshot-container">
+        <button id="screenshotButton" aria-label="Take a screenshot">
+          Take Screenshot
+        </button>
     </div>
 
     <hr />

--- a/src/popup/menu.html
+++ b/src/popup/menu.html
@@ -84,6 +84,7 @@
         <button id="screenshotButton" aria-label="Take a screenshot">
           Take Screenshot
         </button>
+      </div>
     </div>
 
     <hr />

--- a/src/popup/menu.html
+++ b/src/popup/menu.html
@@ -29,22 +29,22 @@
     <div class="form-container">
       <!-- Toggle (Enable/Disable) Borders -->
       <div class="form-group">
-        <label for="toggleBorders" class="label">Toggle Borders:</label>
+        <label for="toggle-borders" class="label">Toggle Borders:</label>
         <input
           type="checkbox"
-          id="toggleBorders"
+          id="toggle-borders"
           aria-label="Enable or disable borders"
         />
       </div>
 
       <!-- Toggle (Enable/Disable) Inspector Mode -->
       <div class="form-group">
-        <label for="toggleInspector" class="label">
+        <label for="toggle-inspector" class="label">
           Toggle Inspector Mode:
         </label>
         <input
           type="checkbox"
-          id="toggleInspector"
+          id="toggle-inspector"
           aria-label="Enable or disable inspector mode"
         />
       </div>
@@ -55,10 +55,10 @@
 
         <!-- Border Size -->
         <div>
-          <label for="borderSize" class="label">Size:</label>
+          <label for="border-size" class="label">Size:</label>
           <input
             type="range"
-            id="borderSize"
+            id="border-size"
             min="1"
             max="3"
             step="0.5"
@@ -69,8 +69,8 @@
 
         <!-- Border Style -->
         <div>
-          <label for="borderStyle" class="label">Style:</label>
-          <select id="borderStyle" aria-label="Border styleß">
+          <label for="border-style" class="label">Style:</label>
+          <select id="border-style" aria-label="Border style">
             <option value="solid">Solid</option>
             <option value="dashed">Dashed</option>
             <option value="dotted">Dotted</option>
@@ -81,7 +81,7 @@
 
       <!-- Screenshot -->
       <div class="screenshot-container">
-        <button id="screenshotButton" aria-label="Take a screenshot">
+        <button id="screenshot-button" aria-label="Take a screenshot">
           Take Screenshot
         </button>
       </div>

--- a/src/popup/menu.js
+++ b/src/popup/menu.js
@@ -7,6 +7,7 @@ const toggleInspector = document.querySelector('#toggleInspector');
 const borderSize = document.querySelector('#borderSize');
 const borderStyle = document.querySelector('#borderStyle');
 const restrictedMessage = document.querySelector('#restricted-message');
+const screenshotButton = document.querySelector('#screenshotButton');
 
 /**
  * Toggles the restricted page state in the popup.
@@ -48,7 +49,8 @@ async function initializeStates() {
     !toggleInspector ||
     !borderSize ||
     !borderStyle ||
-    !restrictedMessage
+    !restrictedMessage ||
+    !screenshotButton
   ) {
     Logger.warn('One or more required DOM elements are missing.');
     return;
@@ -110,6 +112,12 @@ function updateBorderSettings() {
   });
 }
 
+/** Handles the screenshot request */
+function handleScreenshotRequest() {
+  // Send message to background script to capture screenshot
+  chrome.runtime.sendMessage({ action: 'CAPTURE_SCREENSHOT' });
+}
+
 // Run initialization when popup loads
 document.addEventListener('DOMContentLoaded', initializeStates);
 
@@ -118,3 +126,4 @@ toggleBorders?.addEventListener('change', toggleBorderMode);
 toggleInspector?.addEventListener('change', toggleInspectorMode);
 borderSize?.addEventListener('input', updateBorderSettings);
 borderStyle?.addEventListener('change', updateBorderSettings);
+screenshotButton?.addEventListener('click', handleScreenshotRequest);

--- a/src/popup/menu.js
+++ b/src/popup/menu.js
@@ -2,12 +2,12 @@ import { getActiveTab, isRestrictedUrl } from '../scripts/helpers.js';
 import Logger from '../scripts/utils/logger.js';
 
 // Get DOM elements
-const toggleBorders = document.querySelector('#toggleBorders');
-const toggleInspector = document.querySelector('#toggleInspector');
-const borderSize = document.querySelector('#borderSize');
-const borderStyle = document.querySelector('#borderStyle');
+const toggleBorders = document.querySelector('#toggle-borders');
+const toggleInspector = document.querySelector('#toggle-inspector');
+const borderSize = document.querySelector('#border-size');
+const borderStyle = document.querySelector('#border-style');
 const restrictedMessage = document.querySelector('#restricted-message');
-const screenshotButton = document.querySelector('#screenshotButton');
+const screenshotButton = document.querySelector('#screenshot-button');
 
 /**
  * Toggles the restricted page state in the popup.

--- a/src/scripts/utils/filename.js
+++ b/src/scripts/utils/filename.js
@@ -9,6 +9,15 @@
  */
 
 export function getTimestampedScreenshotFilename(format = 'png') {
+  // Ensure the format is lowercase and valid
+  const validFormats = ['png', 'jpg', 'jpeg', 'webp'];
+  if (!validFormats.includes(format.toLowerCase())) {
+    throw new Error(
+      `Invalid format: ${format}. Supported formats: ${validFormats.join(', ')}`
+    );
+  }
+
+  // Generate the timestamped filename
   const timestamp = new Date().toISOString().replace(/[:]/g, '-').split('.')[0];
-  return `border_patrol_screenshot_${timestamp}.{format}`;
+  return `border_patrol_screenshot_${timestamp}.${format}`;
 }

--- a/src/scripts/utils/filename.js
+++ b/src/scripts/utils/filename.js
@@ -1,0 +1,14 @@
+/**
+ * Generates a filename for a screenshot with the current timestamp.
+ *
+ * The filename follows the format 'border_patrol_screenshot_YYYY-MM-DDTHH-MM-SS.png',
+ * where the timestamp is in ISO 8601 format with colons replaced by hyphens and milliseconds removed.
+ *
+ * @param {string} [format='png'] - The file format for the screenshot (Defaults to 'png').
+ * @returns {string} The timestamped filename for the screenshot.
+ */
+
+export function getTimestampedScreenshotFilename(format = 'png') {
+  const timestamp = new Date().toISOString().replace(/[:]/g, '-').split('.')[0];
+  return `border_patrol_screenshot_${timestamp}.{format}`;
+}

--- a/src/scripts/utils/filename.js
+++ b/src/scripts/utils/filename.js
@@ -7,7 +7,6 @@
  * @param {string} [format='png'] - The file format for the screenshot (Defaults to 'png').
  * @returns {string} The timestamped filename for the screenshot.
  */
-
 export function getTimestampedScreenshotFilename(format = 'png') {
   // Ensure the format is lowercase and valid
   const validFormats = ['png', 'jpg', 'jpeg', 'webp'];

--- a/src/scripts/utils/logger.js
+++ b/src/scripts/utils/logger.js
@@ -11,7 +11,7 @@ const LOG_LABEL = '[BORDER PATROL]';
  * @property {function} warn - Logs a warning message
  */
 const Logger = {
-  isDebug: true,
+  isDebug: false,
   info(...args) {
     if (this.isDebug) console.log(`%c${LOG_LABEL}`, 'color: #2374ab', ...args);
   },

--- a/src/scripts/utils/logger.js
+++ b/src/scripts/utils/logger.js
@@ -11,7 +11,7 @@ const LOG_LABEL = '[BORDER PATROL]';
  * @property {function} warn - Logs a warning message
  */
 const Logger = {
-  isDebug: false,
+  isDebug: true,
   info(...args) {
     if (this.isDebug) console.log(`%c${LOG_LABEL}`, 'color: #2374ab', ...args);
   },


### PR DESCRIPTION
## Overview:

This PR introduces a game-changing feature for developers and designers alike: capturing screenshots of the current webpage with Border Patrol outlines and/or inspector overlay visible. With this addition, users can effortlessly document layout issues, share debugged states with teammates, or create tutorials.

### What's New:

- A new screenshot button is added to the popup menu.
- Clicking the button saves the visible layout and prompts the user to select a save location.

### Optimal Use Case:
This feature is particularly useful when used in conjunction with Border Patrol's CSS outlining feature enabled, allowing users to visualize element boundaries, margins, and padding in the screenshot. This makes it an invaluable asset for teams and individuals working on web development projects, streamlining collaboration, debugging, and knowledge-sharing.

Related to issue: #34 
