### PR TITLE
Fixed: Border formatting issue causing multiple border info to shown inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
 - Redesigned the Border Patrol logo with the 'Grandstander' font for a modern, distinctive look.
 - Updated popup checkboxes to modern toggle switches with smooth animations and consistent styling.
 
+### Fixed
+
+- Border formatting issue causing multiple border info to be shown inline.
+
 ## [1.2.4] - 2025-06-08
 
 ### Fixed

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -1,5 +1,6 @@
 import { getElementClassNames } from './helpers';
 import Logger from './utils/logger';
+import { toSentenceCase } from './utils/string-utils';
 
 (function () {
   let isInspectorModeEnabled = false; // Cache the inspector mode state
@@ -173,23 +174,26 @@ import Logger from './utils/logger';
       return `${borders.top.width} ${borders.top.style} ${borders.top.color}`;
     }
     // If borders are not the same, return a formatted string for each border
-    return Object.entries(borders)
-      .map(([side, border]) => {
-        // Skip if border is zero width, none style, or transparent color
-        if (
-          border.width === '0px' ||
-          border.style === 'none' ||
-          border.color === 'transparent'
-        ) {
-          return '';
-        }
-        // Format the border information for each side
-        return `${side.charAt(0).toUpperCase() + side.slice(1)}: ${
-          border.width
-        } ${border.style} ${border.color}`;
-      })
-      .filter(info => info) // Filter out empty strings
-      .join(', '); // Join with a comma
+    return (
+      '<br>' +
+      Object.entries(borders)
+        .map(([side, border]) => {
+          // Skip if border is zero width, none style, or transparent color
+          if (
+            border.width === '0px' ||
+            border.style === 'none' ||
+            border.color === 'transparent'
+          ) {
+            return '';
+          }
+          // Format the border information for each side
+          return `${toSentenceCase(side)}: ${border.width} ${border.style} ${
+            border.color
+          }`;
+        })
+        .filter(info => info) // Filter out empty strings
+        .join('<br>')
+    );
   }
 
   /**

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -125,22 +125,71 @@ import Logger from './utils/logger';
    * @returns {string} The formatted border information (width style color) or an empty string if no border is present
    */
   function getFormattedBorderInfo(computedStyle) {
-    // Extract border information from computed style
-    const borderWidth = computedStyle.borderWidth || '0px';
-    const borderStyle = computedStyle.borderStyle || 'none';
-    const borderColor = computedStyle.borderColor || 'transparent';
+    const borders = {
+      top: {
+        width: computedStyle.borderTopWidth,
+        style: computedStyle.borderTopStyle,
+        color: computedStyle.borderTopColor,
+      },
+      right: {
+        width: computedStyle.borderRightWidth,
+        style: computedStyle.borderRightStyle,
+        color: computedStyle.borderRightColor,
+      },
+      bottom: {
+        width: computedStyle.borderBottomWidth,
+        style: computedStyle.borderBottomStyle,
+        color: computedStyle.borderBottomColor,
+      },
+      left: {
+        width: computedStyle.borderLeftWidth,
+        style: computedStyle.borderLeftStyle,
+        color: computedStyle.borderLeftColor,
+      },
+    };
 
-    // Return empty string if any of the border properties indicate no border
-    if (
-      borderWidth === '0px' ||
-      borderStyle === 'none' ||
-      borderColor === 'transparent'
-    ) {
-      return '';
+    // Check if all borders are zero width, none style, or transparent color
+    const allBordersZero = Object.values(borders).every(border => {
+      return (
+        border.width === '0px' ||
+        border.style === 'none' ||
+        border.color === 'transparent'
+      );
+    });
+
+    if (allBordersZero) return '';
+
+    // Check if all borders have the same width, style, and color
+    const allBordersSame = Object.values(borders).every(border => {
+      return (
+        border.width === borders.top.width &&
+        border.style === borders.top.style &&
+        border.color === borders.top.color
+      );
+    });
+
+    // Return the top border information if all borders are the same
+    if (allBordersSame) {
+      return `${borders.top.width} ${borders.top.style} ${borders.top.color}`;
     }
-
-    // Format the border information
-    return `${borderWidth} ${borderStyle} ${borderColor}`;
+    // If borders are not the same, return a formatted string for each border
+    return Object.entries(borders)
+      .map(([side, border]) => {
+        // Skip if border is zero width, none style, or transparent color
+        if (
+          border.width === '0px' ||
+          border.style === 'none' ||
+          border.color === 'transparent'
+        ) {
+          return '';
+        }
+        // Format the border information for each side
+        return `${side.charAt(0).toUpperCase() + side.slice(1)}: ${
+          border.width
+        } ${border.style} ${border.color}`;
+      })
+      .filter(info => info) // Filter out empty strings
+      .join(', '); // Join with a comma
   }
 
   /**

--- a/src/scripts/utils/string-utils.js
+++ b/src/scripts/utils/string-utils.js
@@ -1,0 +1,12 @@
+/**
+ * Converts a string to sentence case (first letter capitalized, rest lowercase)
+ *
+ * @param {string} str - The string to convert
+ * @returns {string} The string in sentence case
+ * @example
+ * toSentenceCase('hello world'); // 'Hello world'
+ */
+export const toSentenceCase = (str = '') => {
+  if (typeof str !== 'string') return '';
+  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+};


### PR DESCRIPTION
## Overview:

This PR addresses an issue with the `getFormattedBorderInfo` function, where border properties were not being formatted correctly when dealing with elements that have different border styles or colors on each side.
The problem arose from relying on shorthand properties like `borderWidth`, `borderStyle`, and `borderColor`, which can return expanded values when individual sides have different styles.

Example of what was shown if only the bottom had a visible border:
```
Border: 0px 0px 1px none none solid rgb(68, 68, 68) rgb(68, 68, 68) rgb(233, 233, 233)
```

### Changes:
- Updated `getFormattedBorderInfo` function to use longhand properties for each border side.
- Checks if any border exists at all.
- If all four border sides are identical, it outputs a single, concise line with the border style.
- If the borders differ, it lists only the sides with visible borders, each on its own line.

**Misc:**
- Added custom sentence case string util 

These changes have greatly improved the clarity and accuracy of the border formatting output.
