### PR TITLE
Added a script to sync version number from package file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added the CHANGELOG to the landing page website, making it easier for users to stay informed about the latest features and improvements.
+- Implemented a script to automate the synchronization of version numbers across multiple files.
+
+### Changed
+
+- Updated popup menu to display the version number and include a link to the website, replacing the previous GitHub link.
 
 ## [1.3.0] - 2025-06-21
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf dist",
+    "version-sync": "node scripts/version-sync.js",
+    "prebuild": "npm run version-sync",
     "build": "npm run clean && rollup -c",
     "dev": "rollup -c -w"
   },
@@ -15,7 +17,7 @@
     "url": "git+https://github.com/craigsavage/border-patrol.git"
   },
   "keywords": [],
-  "author": "",
+  "author": "Craig Savage",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/craigsavage/border-patrol/issues"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,6 +35,11 @@ const commonPlugins = [
         rename: (name, extension, fullPath) => path.basename(fullPath),
       },
       {
+        src: 'src/assets/img/*.svg',
+        dest: 'dist/assets/img',
+        rename: (name, extension, fullPath) => path.basename(fullPath),
+      },
+      {
         src: 'src/manifest.json',
         dest: 'dist',
         rename: () => 'manifest.json',

--- a/scripts/version-sync.js
+++ b/scripts/version-sync.js
@@ -15,6 +15,19 @@ const packageJsonPath = path.join(rootDir, 'package.json');
 const manifestPath = path.join(rootDir, 'src', 'manifest.json');
 const menuHtmlPath = path.join(rootDir, 'src', 'popup', 'menu.html');
 
+// Check if all required files exist, otherwise throw an error
+const requiredFiles = [
+  { path: packageJsonPath, name: 'package.json' },
+  { path: manifestPath, name: 'manifest.json' },
+  { path: menuHtmlPath, name: 'menu.html' },
+];
+
+for (const file of requiredFiles) {
+  if (!fs.existsSync(file.path)) {
+    throw new Error(`Required file not found: ${file.name} (${file.path})`);
+  }
+}
+
 // Read the current version from package.json
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 const version = packageJson.version;

--- a/scripts/version-sync.js
+++ b/scripts/version-sync.js
@@ -1,0 +1,44 @@
+// This script synchronizes the version number across package.json, manifest.json, and menu.html files.
+// It reads the version from package.json and updates the other files accordingly.
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Get the current directory name in ES module
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Paths to the files we need to update
+const rootDir = path.join(__dirname, '..');
+const packageJsonPath = path.join(rootDir, 'package.json');
+const manifestPath = path.join(rootDir, 'src', 'manifest.json');
+const menuHtmlPath = path.join(rootDir, 'src', 'popup', 'menu.html');
+
+// Read the current version from package.json
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+const version = packageJson.version;
+console.log(`Current version from package.json: ${version}`);
+
+// Update manifest.json
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+if (manifest.version !== version) {
+  manifest.version = version;
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+  console.log(`Updated manifest.json to version ${version}`);
+}
+
+// Update menu.html version in the footer
+let menuHtml = fs.readFileSync(menuHtmlPath, 'utf-8');
+const versionRegex = /<span class="version">.*?<\/span>/;
+
+// Replace the version in the footer
+menuHtml = menuHtml.replace(
+  versionRegex,
+  `<span class="version">v${version}</span>`
+);
+
+fs.writeFileSync(menuHtmlPath, menuHtml);
+console.log(`Updated menu.html with version ${version}`);
+
+console.log('Version sync complete!');

--- a/src/popup/menu.css
+++ b/src/popup/menu.css
@@ -118,19 +118,19 @@ legend {
   right: 0;
   bottom: 0;
   background-color: var(--bp-light-gray);
-  transition: .3s;
+  transition: 0.3s;
   border-radius: 16px;
 }
 
 .slider:before {
   position: absolute;
-  content: "";
+  content: '';
   height: 12px;
   width: 12px;
   left: 2px;
   bottom: 2px;
   background-color: var(--bp-blue-50);
-  transition: .3s;
+  transition: 0.3s;
   border-radius: 50%;
 }
 
@@ -244,4 +244,11 @@ footer {
   text-align: center;
   font-size: 0.8rem;
   color: var(--bp-gray);
+}
+
+.footer-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
 }

--- a/src/popup/menu.html
+++ b/src/popup/menu.html
@@ -97,11 +97,14 @@
 
     <footer>
       <a
-        href="https://github.com/craigsavage/border-patrol"
+        href="https://craigsavage.github.io/border-patrol/"
         target="_blank"
-        aria-label="Border Patrol on GitHub"
+        aria-label="Border Patrol Website"
+        class="footer-link"
       >
-        GitHub
+        <p class="footer-text">
+          Border Patrol <span class="version">v1.3.0</span>
+        </p>
       </a>
     </footer>
   </body>


### PR DESCRIPTION
## Overview

This PR introduces a script to synchronize the version number from the `package.json` file to both `manifest.json` and `menu.html`. The version number is now displayed in the popup menu's footer, which links to the website instead of GitHub.

The main benefit of this change is that we only need to update the version number in one place (`package.json`), making it easier to manage and reducing the chance of version discrepancies.

### How to use:
- Update the version number in the `package.json` file
- Run the command: `npm run build`
  - This will now update the version number set in `package.json`.
 