### PR TITLE
Improve User Experience for Denied Downloads Permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Added the CHANGELOG to the landing page website, making it easier for users to stay informed about the latest features and improvements.
 - Implemented a script to automate the synchronization of version numbers across multiple files.
+- Added feedback for users when attempting to take a screenshot without the necessary downloads permission.
 
 ### Changed
 

--- a/src/popup/menu.css
+++ b/src/popup/menu.css
@@ -28,7 +28,7 @@
 
 body {
   padding: 1rem;
-  width: 16rem;
+  width: 17rem;
   transition: opacity 0.2s ease;
 }
 
@@ -182,27 +182,79 @@ a {
   color: var(--bp-gray);
 }
 
+/* Warning/Error Messages */
+.restricted-message {
+  background-color: #fff3cd;
+  border-left: 4px solid #ffc107;
+  color: #856404;
+  padding: 12px;
+  margin: 12px 0;
+  border-radius: 6px;
+  font-size: 13px;
+  line-height: 1.4;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.restricted-message p {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+}
+
+/* Permission button within warning message */
+.restricted-message .permission-button {
+  background-color: #ffc107;
+  color: #000;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: inline-block;
+}
+
+.restricted-message .permission-button:hover {
+  background-color: #e0a800;
+  transform: translateY(-1px);
+}
+
+.restricted-message .permission-button:active {
+  transform: translateY(0);
+}
+
 /* Screenshot Section */
 .screenshot-container {
   display: flex;
-  justify-content: center;
-  margin: 1rem 0 1rem;
-  padding: 0 0.5rem;
+  flex-direction: column;
+  align-items: stretch;
+  margin: 1rem 0;
+  gap: 12px;
+  position: relative;
+  padding: 0;
+}
+
+#screenshot-permission-warning {
+  display: none;
 }
 
 #screenshot-button {
+  padding: 0.75rem 1.25rem;
   background-color: var(--bp-blue);
-  color: var(--bp-blue-50);
+  color: white;
   border: none;
-  border-radius: 5px;
-  padding: 0.6rem 1.2rem;
-  font-size: 0.8rem;
-  font-weight: 600;
+  border-radius: 6px;
   cursor: pointer;
+  font-weight: 500;
+  font-size: 0.95rem;
   transition: all 0.2s ease;
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: center;
+  gap: 0.75rem;
+  width: 100%;
+  margin: 0;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 

--- a/src/popup/menu.html
+++ b/src/popup/menu.html
@@ -87,7 +87,17 @@
 
       <!-- Screenshot -->
       <div class="screenshot-container">
-        <button id="screenshot-button" aria-label="Take a screenshot">
+        <div id="screenshot-permission-warning" class="restricted-message">
+          <p>Download permission required for screenshots</p>
+          <button id="grant-permission-button" class="permission-button">
+            Grant Permission
+          </button>
+        </div>
+        <button
+          id="screenshot-button"
+          aria-label="Take a screenshot"
+          class="screenshot-button"
+        >
           Take Screenshot
         </button>
       </div>

--- a/src/scripts/helpers.js
+++ b/src/scripts/helpers.js
@@ -43,6 +43,24 @@ export async function getActiveTab() {
 }
 
 /**
+ * Checks if the extension has the specified permission.
+ *
+ * @param {string|string[]} permissions - The permission or array of permissions to check.
+ * @returns {Promise<boolean>} A promise that resolves to true if all permissions are granted.
+ */
+export async function hasPermission(permissions) {
+  const perms = Array.isArray(permissions) ? permissions : [permissions];
+
+  try {
+    // Check if the permissions are already granted
+    return await chrome.permissions.contains({ permissions: perms });
+  } catch (error) {
+    Logger.error('Error checking permissions:', error);
+    return false;
+  }
+}
+
+/**
  * Retrieves and formats the class names of an element.
  * Truncates the list if it exceeds the maximum display length.
  *


### PR DESCRIPTION
## Overview:
When a user denies the `downloads` permission during installation or updates, then they attempt to take a screenshot, the feature fails silently without any feedback due to a lack of permission.

**Problem:**
- The user is not informed that the screenshot feature requires the downloads permission.
- The extension does not provide any feedback when the feature fails due to a missing permission.

## Solution:

- Check for downloads permission before attempting to take a screenshot.
- Provide user-friendly feedback (e.g., in the popup or a browser notification) explaining why the screenshot couldn't be taken and how to grant the permission.
- Added a button in the warning message to allow the user to request the permission on demand.

**Benefits:**
- Improved user experience by providing clear feedback and guidance.
- Enhanced transparency about permission requirements.
