### PR TITLE
Enhance Border Mutation Performance and Code Clean Up

### DIFF
--- a/src/scripts/border.js
+++ b/src/scripts/border.js
@@ -109,19 +109,14 @@ import Logger from './utils/logger';
           });
         });
       } else if (mutation.type === 'attributes') {
-        // Handle attribute changes (e.g., class changes)
+        // Handle attribute changes (e.g., class, style)
+        // Apply outline ONLY to the target element whose attribute changed.
+        // Its children's outlines are independent and should not be re-scanned.
         const targetElement = mutation.target;
         if (targetElement.nodeType !== Node.ELEMENT_NODE) return; // Skip non-element nodes
         if (isInspectorUIElement(targetElement)) return;
 
         applyOutlineToElement(targetElement, outlineSize, outlineStyle);
-
-        // Also apply outline to all child elements of the mutated target
-        targetElement.querySelectorAll('*').forEach(child => {
-          if (isInspectorUIElement(child)) return;
-
-          applyOutlineToElement(child, outlineSize, outlineStyle);
-        });
       }
     });
   }
@@ -129,8 +124,7 @@ import Logger from './utils/logger';
   /**
    * Starts observing the DOM for changes to apply or remove outlines dynamically.
    * This function sets up a MutationObserver to watch for changes in the document body.
-   * It listens for child additions/removals and attribute changes to apply outlines
-   * to newly added elements or those that change their attributes.
+   * It listens for child list changes, attribute changes, and subtree modifications.
    */
   function startObservingDOM() {
     if (!observer) {

--- a/src/scripts/border.js
+++ b/src/scripts/border.js
@@ -38,46 +38,45 @@ import Logger from './utils/logger';
   const defaultColor = 'red';
 
   /**
-   * Checks if an element is part of the Border Patrol Inspector UI.
+   * Determines if the given element is part of the Border Patrol Inspector UI.
    *
-   * @param {Element} element - The element to check.
-   * @returns {boolean} - True if the element is part of the Inspector UI, false otherwise.
+   * @param {Element} element - The element to be checked.
+   * @returns {boolean} True if the element is part of the Inspector UI, otherwise false.
    */
   function isInspectorUIElement(element) {
     if (!bpInspectorContainer || !element) return false;
-    return bpInspectorContainer?.contains(element);
+    return bpInspectorContainer.contains(element);
   }
 
   /**
    * Applies an outline to a given element based on its group and specified size and style.
    *
    * @param {Element} element - The DOM element to apply the outline to.
-   * @param {number} size - The size of the outline in pixels.
-   * @param {string} style - The style of the outline (e.g., 'solid', 'dashed', etc.).
+   * @param {number} outlineSize - The size of the outline in pixels.
+   * @param {string} outlineStyle - The style of the outline (e.g., 'solid', 'dashed', etc.).
    */
-  function applyOutlineToElement(element, size, style) {
+  function applyOutlineToElement(element, outlineSize, outlineStyle) {
     // Ensure the element is a valid DOM element
     if (!(element instanceof Element)) {
-      Logger.warn('Skipping outline application: Not an element instance.');
       return; // Skip if not an element instance
     }
 
     // Exclude applying outlines to Border Patrol elements
     if (isInspectorUIElement(element)) return;
 
-    const tag = element.tagName.toLowerCase();
-    let color = defaultColor;
+    const elementTag = element.tagName.toLowerCase();
+    let outlineColor = defaultColor;
 
     // Determine element's group and apply corresponding color
     for (const { tags, color: groupColor } of Object.values(elementGroups)) {
-      if (tags.includes(tag)) {
-        color = groupColor;
+      if (tags.includes(elementTag)) {
+        outlineColor = groupColor;
         break; // Stop searching once a match is found
       }
     }
 
     // Apply the outline style to the element
-    element.style.outline = `${size}px ${style} ${color}`;
+    element.style.outline = `${outlineSize}px ${outlineStyle} ${outlineColor}`;
   }
 
   /**

--- a/src/scripts/border.js
+++ b/src/scripts/border.js
@@ -94,17 +94,11 @@ import Logger from './utils/logger';
         mutation.addedNodes.forEach(node => {
           if (node.nodeType !== Node.ELEMENT_NODE) return; // Skip non-element nodes
 
-          // Skip Border Patrol Inspector UI elements
-          if (isInspectorUIElement(node)) return;
-
           // Apply outline to the newly added node
           applyOutlineToElement(node, outlineSize, outlineStyle);
 
           // Apply outline to all child elements of the newly added node
           node.querySelectorAll('*').forEach(child => {
-            // Skip Border Patrol Inspector UI elements
-            if (isInspectorUIElement(child)) return;
-
             applyOutlineToElement(child, outlineSize, outlineStyle);
           });
         });


### PR DESCRIPTION
## Overview:

This PR aims to refine the mutation logic previously added (https://github.com/craigsavage/border-patrol/pull/71) and implement improvements to significantly enhance performance.

- Added an `attributeFilter: ['class', 'style']` to the `MutationObserver` configuration, so that it is only triggered when a mutation record's class or style attributes change on an observed element.
  > This is important because without the targeted `attributeFilter`, the `MutationObserver` would fire for any attribute change (e.g., `id, src, href, data-* attributes, etc...`). Many of these changes are irrelevant to applying borders and just generate unnecessary work for your `handleMutations` function.
- Removed the child loop from the attributes mutation handling as it is a major cause of performance issues on complex pages.
  > This is because re-scanning and re-applying borders to the entire subtree of a `targetElement` on an attribute change is a huge waste of resources (e.g., a class change on `body` would result in the entire tree updating).
- Removed redundant `isInspectorUIElement` checks within `handleMutations` as they're already handled in the `applyOutlineToElement` function.

**Extras:**
 - Improves the readability of the `handleMutations` function.
