### PR TITLE
Add Keyboard Shortcut for Inspector Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - UNRELEASED
+
+### Added
+
+- Added new keyboard shortcut (`"Alt+Shift+I"`) for toggling inspector mode
+
 ## [1.4.0] - 2025-07-30
 
 ### Added
@@ -134,7 +140,7 @@ All notable changes to this project will be documented in this file.
 - Resolved issues where the popup menu's display wasn't updating correctly.
 - Fixed critical connection and state synchronization issues for more reliable functionality.
 - Borders now apply correctly immediately after installation.
-- Changed the keyboard shortcut for toggling borders to `'Alt+Shift+B'` to avoid conflicts and ensure it works reliably.
+- Changed the keyboard shortcut for toggling borders to `"Alt+Shift+B"` to avoid conflicts and ensure it works reliably.
 - Inspector mode now correctly deactivates after extension reload or on restricted pages.
 - Corrected inspector overlay position when scrolling or with the console open.
 - Improved resource management by cleaning up data when tabs are closed.

--- a/src/background.js
+++ b/src/background.js
@@ -564,4 +564,34 @@ chrome.commands.onCommand.addListener(async command => {
       return;
     }
   }
+
+  // Toggle the inspector for the active tab
+  else if (command === 'toggle_inspector_mode') {
+    let tabId;
+
+    try {
+      // Get the active tab to determine which tab to toggle
+      const activeTab = await getActiveTab();
+      if (!activeTab?.id || !activeTab?.url || isRestrictedUrl(activeTab.url)) {
+        Logger.warn('Ignoring command on restricted or invalid tab.');
+        return;
+      }
+      tabId = activeTab.id;
+
+      // Get current state and toggle inspector mode
+      const currentState = await getTabState({ tabId });
+      const newState = !currentState.inspectorMode;
+
+      // Handle the state change centrally
+      await handleTabStateChange({
+        tabId,
+        states: { inspectorMode: newState },
+      });
+    } catch (error) {
+      Logger.error(`Error toggling inspector mode for tab ${tabId}:`, error);
+      return;
+    }
+  } else {
+    Logger.warn('Unknown command received:', command);
+  }
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,6 +26,13 @@
         "mac": "Alt+Shift+B"
       },
       "description": "Toggle Border Patrol"
+    },
+    "toggle_inspector_mode": {
+      "suggested_key": {
+        "default": "Alt+Shift+I",
+        "mac": "Alt+Shift+I"
+      },
+      "description": "Toggle Inspector Mode"
     }
   },
   "web_accessible_resources": [

--- a/src/scripts/helpers.js
+++ b/src/scripts/helpers.js
@@ -27,17 +27,22 @@ export function isRestrictedUrl(url) {
 /**
  * Retrieves the active tab in the current window.
  *
+ * The active tab is the last focused tab in the current window.
+ * If no tab is found, an empty object is returned.
+ *
  * @returns {Promise<chrome.tabs.Tab>} The active tab object, or an empty object if not found.
  */
 export async function getActiveTab() {
   try {
-    const [tab] = await chrome.tabs.query({
+    // Query for the active tab in the current window
+    const tabs = await chrome.tabs.query({
       active: true,
       lastFocusedWindow: true,
     });
-    return tab ?? {};
+
+    // Return the first tab found, or an empty object if none are found
+    return tabs[0] ?? {};
   } catch (error) {
-    Logger.error('Error retrieving active tab:', error);
     return {};
   }
 }

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -18,11 +18,11 @@ import { toSentenceCase } from './utils/string-utils';
   const MAX_CLASS_DISPLAY_LENGTH = 50; // Maximum length of class names to display
   const OVERLAY_MARGIN = 10; // Margin from cursor position to overlay position
 
-  // Colors for box model visualization
-  const MARGIN_COLOR = 'rgba(255, 165, 0, 0.3)'; // Orange with transparency
-  const BORDER_COLOR = 'rgba(255, 255, 0, 0.3)'; // Yellow with transparency
-  const PADDING_COLOR = 'rgba(0, 128, 0, 0.3)'; // Green with transparency
-  const CONTENT_COLOR = 'rgba(0, 0, 255, 0.3)'; // Blue with transparency
+  // Colors for box model visualization (rgba with transparency)
+  const MARGIN_COLOR = 'rgba(255, 165, 0, 0.3)'; // Orange
+  const BORDER_COLOR = 'rgba(255, 255, 0, 0.3)'; // Yellow
+  const PADDING_COLOR = 'rgba(0, 128, 0, 0.3)'; // Green
+  const CONTENT_COLOR = 'rgba(0, 0, 255, 0.3)'; // Blue
 
   /**
    * Handles the inspector mode update


### PR DESCRIPTION
## Overview:

This PR adds a new shortcut for toggling inspector mode via the new default command `"Alt+Shift+I"`

Fixes Issue: #84 
