### PR TITLE
Add area highlighting to ruler mode

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,9 +21,11 @@ This repository is a Manifest V3 browser extension built with TypeScript, React,
 - Prefer small, targeted changes that preserve the existing file layout and naming.
 - Follow the existing TypeScript style: strict typing, function components, async Chrome API calls, and early returns for guard clauses.
 - Add concise docstrings (JSDoc-style) to all exported functions and major helpers. Docstrings should briefly describe purpose, parameters, and return values where relevant.
+- Code should be clean and modular. Avoid large functions, break complex logic into smaller related pieces if necessary.
 - Keep comments sparse elsewhere. Add them only where the logic is not obvious.
 - Reuse existing helpers before adding new ones.
 - Keep popup logic in hooks/components and extension runtime logic in background or content-script modules.
+- Use descriptive variable and function names to enhance readability without needing excessive comments.
 
 ## Extension Behavior Constraints
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,7 +20,7 @@ Enables on-page measurements so you can check spacing and alignment without leav
 
 ### Ruler Mode
 
-Toggle a pixel ruler along the top and left edges of the page. Rulers display page coordinates (updated as you scroll), with tick marks every 50 px and labels every 200 px. A blush-colored crosshair line on each ruler tracks your mouse position in real time. Fully theme-aware — responds to the extension's dark mode setting.
+Toggle a pixel ruler along the top and left edges of the page. Rulers display page coordinates (updated as you scroll), with tick marks every 50 px and labels every 200 px. A blush-colored crosshair line on each ruler tracks your mouse position in real time. Click any element on the page to highlight its bounds on both rulers — the selected region is filled with a blue band and labeled with its start and end coordinates. Ticks and labels within the highlighted range are dimmed so the selection stands out, and any regular tick label that would collide with a selection label is automatically hidden. Fully theme-aware — responds to the extension's dark mode setting.
 
 ## Screenshot Tool
 

--- a/src/scripts/measurement.ts
+++ b/src/scripts/measurement.ts
@@ -529,40 +529,12 @@ import MEASUREMENT_STYLES from '../styles/components/measurement.shadow.scss';
     repositionAll();
   }
 
-  /**
-   * Dispatches a custom window event with the current selection's page-coordinate rects
-   * so other modules (e.g., ruler) can react to selection changes.
-   */
-  function dispatchSelectionEvent(): void {
-    const toPageRect = (el: HTMLElement | null) => {
-      if (!el) return null;
-      const r = el.getBoundingClientRect();
-      return {
-        left: r.left + window.scrollX,
-        right: r.right + window.scrollX,
-        top: r.top + window.scrollY,
-        bottom: r.bottom + window.scrollY,
-        width: r.width,
-        height: r.height,
-      };
-    };
-    window.dispatchEvent(
-      new CustomEvent('bp-measurement-selection', {
-        detail: {
-          firstRect: toPageRect(firstSelected),
-          secondRect: toPageRect(secondSelected),
-        },
-      }),
-    );
-  }
-
   /** Clears the current selection state and hides overlays. */
   function resetSelection(): void {
     firstSelected = null;
     secondSelected = null;
     hoveredElement = null;
     hideAll();
-    dispatchSelectionEvent();
   }
 
   /**
@@ -619,7 +591,6 @@ import MEASUREMENT_STYLES from '../styles/components/measurement.shadow.scss';
       if (firstHighlight) positionHighlight(firstHighlight, target, true);
       if (firstBadge) positionBadge(firstBadge, target);
       if (firstSizeLabel) positionSizeLabel(firstSizeLabel, target);
-      dispatchSelectionEvent();
     } else if (!secondSelected && target !== firstSelected) {
       // Second selection
       secondSelected = target;
@@ -628,7 +599,6 @@ import MEASUREMENT_STYLES from '../styles/components/measurement.shadow.scss';
       if (secondBadge) positionBadge(secondBadge, target);
       if (secondSizeLabel) positionSizeLabel(secondSizeLabel, target);
       drawConnector();
-      dispatchSelectionEvent();
     }
   }
 
@@ -697,12 +667,6 @@ import MEASUREMENT_STYLES from '../styles/components/measurement.shadow.scss';
       removeEventListeners();
       resetSelection();
       removeElements();
-      // Ensure ruler clears any selection highlight even after DOM cleanup
-      window.dispatchEvent(
-        new CustomEvent('bp-measurement-selection', {
-          detail: { firstRect: null, secondRect: null },
-        }),
-      );
     }
   }
 

--- a/src/scripts/measurement.ts
+++ b/src/scripts/measurement.ts
@@ -529,12 +529,40 @@ import MEASUREMENT_STYLES from '../styles/components/measurement.shadow.scss';
     repositionAll();
   }
 
+  /**
+   * Dispatches a custom window event with the current selection's page-coordinate rects
+   * so other modules (e.g., ruler) can react to selection changes.
+   */
+  function dispatchSelectionEvent(): void {
+    const toPageRect = (el: HTMLElement | null) => {
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return {
+        left: r.left + window.scrollX,
+        right: r.right + window.scrollX,
+        top: r.top + window.scrollY,
+        bottom: r.bottom + window.scrollY,
+        width: r.width,
+        height: r.height,
+      };
+    };
+    window.dispatchEvent(
+      new CustomEvent('bp-measurement-selection', {
+        detail: {
+          firstRect: toPageRect(firstSelected),
+          secondRect: toPageRect(secondSelected),
+        },
+      }),
+    );
+  }
+
   /** Clears the current selection state and hides overlays. */
   function resetSelection(): void {
     firstSelected = null;
     secondSelected = null;
     hoveredElement = null;
     hideAll();
+    dispatchSelectionEvent();
   }
 
   /**
@@ -591,6 +619,7 @@ import MEASUREMENT_STYLES from '../styles/components/measurement.shadow.scss';
       if (firstHighlight) positionHighlight(firstHighlight, target, true);
       if (firstBadge) positionBadge(firstBadge, target);
       if (firstSizeLabel) positionSizeLabel(firstSizeLabel, target);
+      dispatchSelectionEvent();
     } else if (!secondSelected && target !== firstSelected) {
       // Second selection
       secondSelected = target;
@@ -599,6 +628,7 @@ import MEASUREMENT_STYLES from '../styles/components/measurement.shadow.scss';
       if (secondBadge) positionBadge(secondBadge, target);
       if (secondSizeLabel) positionSizeLabel(secondSizeLabel, target);
       drawConnector();
+      dispatchSelectionEvent();
     }
   }
 
@@ -667,6 +697,12 @@ import MEASUREMENT_STYLES from '../styles/components/measurement.shadow.scss';
       removeEventListeners();
       resetSelection();
       removeElements();
+      // Ensure ruler clears any selection highlight even after DOM cleanup
+      window.dispatchEvent(
+        new CustomEvent('bp-measurement-selection', {
+          detail: { firstRect: null, secondRect: null },
+        }),
+      );
     }
   }
 

--- a/src/scripts/ruler.ts
+++ b/src/scripts/ruler.ts
@@ -517,33 +517,33 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       const MIN_OUTSIDE = Math.round(20 * dpr);
       const GAP = Math.round(4 * dpr);
 
-      // Start (top) label — outside means above the start line (negative rotated-x direction)
+      // Start (top) label — outside means above the start line (positive rotated-x → negative canvas Y offset)
       const startLabelText = String(Math.round(rect.top));
       ctx.save();
       ctx.textBaseline = 'middle';
       ctx.translate(Math.round(pw * 0.5), startCanvasY);
       ctx.rotate(-Math.PI / 2);
       if (startCanvasY >= MIN_OUTSIDE) {
-        ctx.textAlign = 'right';
-        ctx.fillText(startLabelText, -GAP, 0);
-      } else {
         ctx.textAlign = 'left';
         ctx.fillText(startLabelText, GAP, 0);
+      } else {
+        ctx.textAlign = 'right';
+        ctx.fillText(startLabelText, -GAP, 0);
       }
       ctx.restore();
 
-      // End (bottom) label — outside means below the end line (positive rotated-x direction)
+      // End (bottom) label — outside means below the end line (negative rotated-x → positive canvas Y offset)
       const endLabelText = String(Math.round(rect.bottom));
       ctx.save();
       ctx.textBaseline = 'middle';
       ctx.translate(Math.round(pw * 0.5), endCanvasY);
       ctx.rotate(-Math.PI / 2);
       if (endCanvasY <= ph - MIN_OUTSIDE) {
-        ctx.textAlign = 'left';
-        ctx.fillText(endLabelText, GAP, 0);
-      } else {
         ctx.textAlign = 'right';
         ctx.fillText(endLabelText, -GAP, 0);
+      } else {
+        ctx.textAlign = 'left';
+        ctx.fillText(endLabelText, GAP, 0);
       }
       ctx.restore();
     }

--- a/src/scripts/ruler.ts
+++ b/src/scripts/ruler.ts
@@ -51,9 +51,9 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         bg: '#333', // bp-dark-gray
         border: '#555', // mid-gray border
         tick: '#92c7e7', // bp-blue-300
-        tickDim: '#555', // same as border — barely visible inside selection
+        tickDim: '#6b7280', // mid-gray — muted but still readable inside selection
         label: '#c5e0f2', // bp-blue-200
-        labelDim: 'rgba(197, 224, 242, 0.25)', // bp-blue-200 at 25%
+        labelDim: 'rgba(197, 224, 242, 0.5)', // bp-blue-200 at 50%
         crosshair: '#aa4465', // bp-blush-600
         selectionFill: 'rgba(146, 199, 231, 0.3)', // bp-blue-300 at 30%
         selectionEdge: '#92c7e7', // bp-blue-300
@@ -63,9 +63,9 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       bg: '#f2f8fd', // bp-blue-50
       border: '#c5e0f2', // bp-blue-200
       tick: '#57a9d9', // bp-blue-400
-      tickDim: '#c5e0f2', // bp-blue-200 — recedes inside selection
+      tickDim: '#8ab7d3', // bp-blue-350 — lighter than tick but not invisible
       label: '#1d5a87', // bp-blue-700
-      labelDim: 'rgba(29, 90, 135, 0.25)', // bp-blue-700 at 25%
+      labelDim: 'rgba(29, 90, 135, 0.5)', // bp-blue-700 at 50%
       crosshair: '#aa4465', // bp-blush-600
       selectionFill: 'rgba(42, 125, 181, 0.5)', // bp-blue-500 at 50%
       selectionEdge: '#2a7db5', // bp-blue-500
@@ -283,29 +283,28 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       ctx.fillStyle = colors.selectionEdge;
       ctx.textBaseline = 'top';
       const labelY = Math.round(2 * dpr);
+      // Minimum canvas-pixel gap needed to fit a label outside; anything less forces inside.
+      const MIN_OUTSIDE = Math.round(20 * dpr);
+      const GAP = Math.round(4 * dpr);
 
-      // Start label — right-aligned just before the edge line, or left-aligned if at canvas start
+      // Start label — outside (to the left) unless the edge is too close to the canvas boundary
       const startLabelText = String(Math.round(rect.left));
-      if (startCanvasX > 2 * dpr) {
+      if (startCanvasX >= MIN_OUTSIDE) {
         ctx.textAlign = 'right';
-        ctx.fillText(startLabelText, startCanvasX - Math.round(dpr), labelY);
+        ctx.fillText(startLabelText, startCanvasX - GAP, labelY);
       } else {
         ctx.textAlign = 'left';
-        ctx.fillText(
-          startLabelText,
-          startCanvasX + Math.round(2 * dpr),
-          labelY,
-        );
+        ctx.fillText(startLabelText, startCanvasX + GAP, labelY);
       }
 
-      // End label — left-aligned just after the edge line, or right-aligned if at canvas end
+      // End label — outside (to the right) unless the edge is too close to the canvas right boundary
       const endLabelText = String(Math.round(rect.right));
-      if (endCanvasX < pw - 2 * dpr) {
+      if (endCanvasX <= pw - MIN_OUTSIDE) {
         ctx.textAlign = 'left';
-        ctx.fillText(endLabelText, endCanvasX + Math.round(2 * dpr), labelY);
+        ctx.fillText(endLabelText, endCanvasX + GAP, labelY);
       } else {
         ctx.textAlign = 'right';
-        ctx.fillText(endLabelText, endCanvasX - Math.round(dpr), labelY);
+        ctx.fillText(endLabelText, endCanvasX - GAP, labelY);
       }
     }
 
@@ -429,37 +428,37 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
 
       // Labels: page Y coordinate at each edge, rotated -90°
       ctx.fillStyle = colors.selectionEdge;
+      // Minimum canvas-pixel gap needed to fit a label outside; anything less forces inside.
+      const MIN_OUTSIDE = Math.round(20 * dpr);
+      const GAP = Math.round(4 * dpr);
 
-      // Start (top) label
+      // Start (top) label — outside means above the start line (negative rotated-x direction)
       const startLabelText = String(Math.round(rect.top));
       ctx.save();
       ctx.textBaseline = 'middle';
-      ctx.textAlign = 'center';
       ctx.translate(Math.round(pw * 0.5), startCanvasY);
       ctx.rotate(-Math.PI / 2);
-      // Position label above the edge line (to its left when reading the rotated text)
-      if (startCanvasY > 2 * dpr) {
+      if (startCanvasY >= MIN_OUTSIDE) {
         ctx.textAlign = 'right';
-        ctx.fillText(startLabelText, -Math.round(dpr), 0);
+        ctx.fillText(startLabelText, -GAP, 0);
       } else {
         ctx.textAlign = 'left';
-        ctx.fillText(startLabelText, Math.round(2 * dpr), 0);
+        ctx.fillText(startLabelText, GAP, 0);
       }
       ctx.restore();
 
-      // End (bottom) label
+      // End (bottom) label — outside means below the end line (positive rotated-x direction)
       const endLabelText = String(Math.round(rect.bottom));
       ctx.save();
       ctx.textBaseline = 'middle';
-      ctx.textAlign = 'center';
       ctx.translate(Math.round(pw * 0.5), endCanvasY);
       ctx.rotate(-Math.PI / 2);
-      if (endCanvasY < ph - 2 * dpr) {
+      if (endCanvasY <= ph - MIN_OUTSIDE) {
         ctx.textAlign = 'left';
-        ctx.fillText(endLabelText, Math.round(2 * dpr), 0);
+        ctx.fillText(endLabelText, GAP, 0);
       } else {
         ctx.textAlign = 'right';
-        ctx.fillText(endLabelText, -Math.round(dpr), 0);
+        ctx.fillText(endLabelText, -GAP, 0);
       }
       ctx.restore();
     }

--- a/src/scripts/ruler.ts
+++ b/src/scripts/ruler.ts
@@ -29,6 +29,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
   let cornerDiv: HTMLElement | null = null;
   let selectedElement: Element | null = null;
   let selectionHighlight: HTMLElement | null = null;
+  let hoveredElement: Element | null = null;
+  let hoverHighlight: HTMLElement | null = null;
 
   interface RulerColors {
     bg: string;
@@ -40,6 +42,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     crosshair: string;
     selectionFill: string;
     selectionEdge: string;
+    hoverFill: string;
+    hoverEdge: string;
   }
 
   /**
@@ -59,6 +63,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         crosshair: '#aa4465', // bp-blush-600
         selectionFill: 'rgba(146, 199, 231, 0.3)', // bp-blue-300 at 30%
         selectionEdge: '#92c7e7', // bp-blue-300
+        hoverFill: 'rgba(146, 199, 231, 0.12)', // bp-blue-300 at 12% — subtle hover tint
+        hoverEdge: 'rgba(146, 199, 231, 0.6)', // bp-blue-300 at 60%
       };
     }
     return {
@@ -71,6 +77,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       crosshair: '#aa4465', // bp-blush-600
       selectionFill: 'rgba(42, 125, 181, 0.5)', // bp-blue-500 at 50%
       selectionEdge: '#2a7db5', // bp-blue-500
+      hoverFill: 'rgba(42, 125, 181, 0.12)', // bp-blue-500 at 12% — subtle hover tint
+      hoverEdge: 'rgba(42, 125, 181, 0.65)', // bp-blue-500 at 65%
     };
   }
 
@@ -150,6 +158,20 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       selectionHighlight.style.position = 'fixed';
       rulerRoot.appendChild(selectionHighlight);
     }
+
+    // Hover highlight shown over the element currently under the cursor
+    hoverHighlight = rulerRoot.getElementById(
+      'bp-ruler-hover',
+    ) as HTMLElement | null;
+    if (!hoverHighlight) {
+      hoverHighlight = document.createElement('div');
+      hoverHighlight.id = 'bp-ruler-hover';
+      hoverHighlight.style.display = 'none';
+      hoverHighlight.style.pointerEvents = 'none';
+      hoverHighlight.style.boxSizing = 'border-box';
+      hoverHighlight.style.position = 'fixed';
+      rulerRoot.appendChild(hoverHighlight);
+    }
   }
 
   /**
@@ -205,6 +227,63 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     selectionHighlight.style.backgroundColor = colors.selectionFill;
     selectionHighlight.style.outline = `2px solid ${colors.selectionEdge}`;
     selectionHighlight.style.display = 'block';
+  }
+
+  /**
+   * Checks if an element belongs to any Border Patrol UI container.
+   *
+   * @param target - The element to check.
+   * @returns True if the element is part of BP UI.
+   */
+  function isRulerBPElement(target: Element): boolean {
+    if (
+      rulerContainer &&
+      (rulerContainer === target || rulerContainer.contains(target))
+    )
+      return true;
+    for (const id of ['bp-measurement-container', 'bp-inspector-container']) {
+      const el = document.getElementById(id);
+      if (el && (el === target || el.contains(target))) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Positions and shows the hover highlight overlay over the given element.
+   *
+   * @param element - The page element to highlight.
+   */
+  function positionHoverHighlight(element: Element): void {
+    if (!hoverHighlight) return;
+    const rect = element.getBoundingClientRect();
+    const colors = getColors();
+    hoverHighlight.style.top = `${rect.top}px`;
+    hoverHighlight.style.left = `${rect.left}px`;
+    hoverHighlight.style.width = `${rect.width}px`;
+    hoverHighlight.style.height = `${rect.height}px`;
+    hoverHighlight.style.backgroundColor = colors.hoverFill;
+    hoverHighlight.style.outline = `2px solid ${colors.hoverEdge}`;
+    hoverHighlight.style.display = 'block';
+  }
+
+  /**
+   * Handles mouseover events to preview the element under the cursor.
+   *
+   * @param event - The mouse event.
+   */
+  function handleMouseOver(event: MouseEvent): void {
+    const target = event.target as Element;
+    if (!target || !(target instanceof Element)) return;
+    if (isRulerBPElement(target)) return;
+    if (target === selectedElement) return;
+    hoveredElement = target;
+    positionHoverHighlight(target);
+  }
+
+  /** Handles mouseout events to hide the hover highlight. */
+  function handleMouseOut(): void {
+    hoveredElement = null;
+    if (hoverHighlight) hoverHighlight.style.display = 'none';
   }
 
   /**
@@ -619,6 +698,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
 
   function handleScroll(): void {
     if (selectedElement) positionSelectionHighlight(selectedElement);
+    if (hoveredElement) positionHoverHighlight(hoveredElement);
     scheduleRedraw();
   }
 
@@ -626,6 +706,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     sizeCanvases();
     applyCornerTheme();
     if (selectedElement) positionSelectionHighlight(selectedElement);
+    if (hoveredElement) positionHoverHighlight(hoveredElement);
     scheduleRedraw();
   }
 
@@ -644,6 +725,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     isDarkMode = !!changes.darkMode.newValue;
     applyCornerTheme();
     if (selectedElement) positionSelectionHighlight(selectedElement);
+    if (hoveredElement) positionHoverHighlight(hoveredElement);
     scheduleRedraw();
   }
 
@@ -687,11 +769,15 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     ];
     selectedElement = target;
     positionSelectionHighlight(target);
+    if (hoverHighlight) hoverHighlight.style.display = 'none';
+    hoveredElement = null;
     scheduleRedraw();
   }
 
   function addEventListeners(): void {
     document.addEventListener('mousemove', handleMouseMove, { passive: true });
+    document.addEventListener('mouseover', handleMouseOver, true);
+    document.addEventListener('mouseout', handleMouseOut, true);
     window.addEventListener('scroll', handleScroll, { passive: true });
     window.addEventListener('resize', handleResize, { passive: true });
     document.addEventListener('click', handleRulerClick, true);
@@ -700,6 +786,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
 
   function removeEventListeners(): void {
     document.removeEventListener('mousemove', handleMouseMove);
+    document.removeEventListener('mouseover', handleMouseOver, true);
+    document.removeEventListener('mouseout', handleMouseOut, true);
     window.removeEventListener('scroll', handleScroll);
     window.removeEventListener('resize', handleResize);
     document.removeEventListener('click', handleRulerClick, true);
@@ -716,6 +804,9 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     hCanvas = null;
     vCanvas = null;
     cornerDiv = null;
+    selectionHighlight = null;
+    hoverHighlight = null;
+    hoveredElement = null;
   }
 
   /**

--- a/src/scripts/ruler.ts
+++ b/src/scripts/ruler.ts
@@ -61,7 +61,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       tick: '#57a9d9', // bp-blue-400
       label: '#1d5a87', // bp-blue-700
       crosshair: '#aa4465', // bp-blush-600
-      selectionFill: 'rgba(87, 169, 217, 0.3)', // bp-blue-400 at 30%
+      selectionFill: 'rgba(42, 125, 181, 0.5)', // bp-blue-500 at 50%
       selectionEdge: '#2a7db5', // bp-blue-500
     };
   }
@@ -243,7 +243,12 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       ctx.fillStyle = colors.selectionFill;
       const clampedStart = Math.max(0, startCanvasX);
       const clampedEnd = Math.min(pw, endCanvasX);
-      ctx.fillRect(clampedStart, 0, clampedEnd - clampedStart, ph - Math.max(1, dpr));
+      ctx.fillRect(
+        clampedStart,
+        0,
+        clampedEnd - clampedStart,
+        ph - Math.max(1, dpr),
+      );
 
       // Edge lines at start and end
       ctx.fillStyle = colors.selectionEdge;
@@ -266,7 +271,11 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         ctx.fillText(startLabelText, startCanvasX - Math.round(dpr), labelY);
       } else {
         ctx.textAlign = 'left';
-        ctx.fillText(startLabelText, startCanvasX + Math.round(2 * dpr), labelY);
+        ctx.fillText(
+          startLabelText,
+          startCanvasX + Math.round(2 * dpr),
+          labelY,
+        );
       }
 
       // End label — left-aligned just after the edge line, or right-aligned if at canvas end
@@ -368,7 +377,12 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       ctx.fillStyle = colors.selectionFill;
       const clampedStart = Math.max(0, startCanvasY);
       const clampedEnd = Math.min(ph, endCanvasY);
-      ctx.fillRect(0, clampedStart, pw - Math.max(1, dpr), clampedEnd - clampedStart);
+      ctx.fillRect(
+        0,
+        clampedStart,
+        pw - Math.max(1, dpr),
+        clampedEnd - clampedStart,
+      );
 
       // Edge lines at top and bottom
       ctx.fillStyle = colors.selectionEdge;
@@ -472,19 +486,38 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
   }
 
   /**
-   * Handles bp-measurement-selection events dispatched by measurement.ts.
-   * Updates the stored selected page-coordinate rects and schedules a redraw.
+   * Handles click events for ruler selection highlighting.
+   * Clicking any page element replaces the previous ruler selection with that element's bounds.
+   * Does not consume the event so normal page behaviour is preserved.
    *
-   * @param event - The CustomEvent carrying firstRect and secondRect.
+   * @param event - The mouse event.
    */
-  function handleMeasurementSelection(event: Event): void {
-    const { firstRect, secondRect } = (event as CustomEvent).detail as {
-      firstRect: SelectedPageRect | null;
-      secondRect: SelectedPageRect | null;
-    };
-    selectedRects = [];
-    if (firstRect) selectedRects.push(firstRect);
-    if (secondRect) selectedRects.push(secondRect);
+  function handleRulerClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement;
+    if (!target || !(target instanceof HTMLElement)) return;
+
+    // Ignore clicks on the ruler itself and other BP UI containers
+    if (
+      rulerContainer &&
+      (rulerContainer === target || rulerContainer.contains(target))
+    )
+      return;
+    for (const id of ['bp-measurement-container', 'bp-inspector-container']) {
+      const el = document.getElementById(id);
+      if (el && (el === target || el.contains(target))) return;
+    }
+
+    const r = target.getBoundingClientRect();
+    selectedRects = [
+      {
+        left: r.left + window.scrollX,
+        right: r.right + window.scrollX,
+        top: r.top + window.scrollY,
+        bottom: r.bottom + window.scrollY,
+        width: r.width,
+        height: r.height,
+      },
+    ];
     scheduleRedraw();
   }
 
@@ -492,7 +525,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     document.addEventListener('mousemove', handleMouseMove, { passive: true });
     window.addEventListener('scroll', handleScroll, { passive: true });
     window.addEventListener('resize', handleResize, { passive: true });
-    window.addEventListener('bp-measurement-selection', handleMeasurementSelection);
+    document.addEventListener('click', handleRulerClick, true);
     chrome.storage.onChanged.addListener(handleStorageChange);
   }
 
@@ -500,7 +533,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     document.removeEventListener('mousemove', handleMouseMove);
     window.removeEventListener('scroll', handleScroll);
     window.removeEventListener('resize', handleResize);
-    window.removeEventListener('bp-measurement-selection', handleMeasurementSelection);
+    document.removeEventListener('click', handleRulerClick, true);
     chrome.storage.onChanged.removeListener(handleStorageChange);
   }
 

--- a/src/scripts/ruler.ts
+++ b/src/scripts/ruler.ts
@@ -10,6 +10,17 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
 
   const RULER_SIZE = 20; // CSS pixels — thickness of each ruler bar
 
+  // Selection highlight state, fed by bp-measurement-selection events
+  interface SelectedPageRect {
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+    width: number;
+    height: number;
+  }
+  let selectedRects: SelectedPageRect[] = [];
+
   // Shadow DOM refs
   let rulerContainer: HTMLElement | null = null;
   let rulerRoot: ShadowRoot | null = null;
@@ -23,6 +34,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     tick: string;
     label: string;
     crosshair: string;
+    selectionFill: string;
+    selectionEdge: string;
   }
 
   /**
@@ -38,6 +51,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         tick: '#92c7e7', // bp-blue-300
         label: '#c5e0f2', // bp-blue-200
         crosshair: '#aa4465', // bp-blush-600
+        selectionFill: 'rgba(146, 199, 231, 0.3)', // bp-blue-300 at 30%
+        selectionEdge: '#92c7e7', // bp-blue-300
       };
     }
     return {
@@ -46,6 +61,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       tick: '#57a9d9', // bp-blue-400
       label: '#1d5a87', // bp-blue-700
       crosshair: '#aa4465', // bp-blush-600
+      selectionFill: 'rgba(87, 169, 217, 0.3)', // bp-blue-400 at 30%
+      selectionEdge: '#2a7db5', // bp-blue-500
     };
   }
 
@@ -212,6 +229,57 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       }
     }
 
+    // Selection range highlights from Measurement Mode
+    ctx.font = `bold ${Math.round(9 * dpr)}px system-ui,-apple-system,sans-serif`;
+    for (const rect of selectedRects) {
+      const startScreenX = rect.left - scrollX;
+      const endScreenX = rect.right - scrollX;
+      const startCanvasX = Math.round(startScreenX * dpr);
+      const endCanvasX = Math.round(endScreenX * dpr);
+      const rangeW = endCanvasX - startCanvasX;
+      if (rangeW <= 0 || endCanvasX < 0 || startCanvasX > pw) continue;
+
+      // Filled band across the ruler height (excluding the bottom border pixel)
+      ctx.fillStyle = colors.selectionFill;
+      const clampedStart = Math.max(0, startCanvasX);
+      const clampedEnd = Math.min(pw, endCanvasX);
+      ctx.fillRect(clampedStart, 0, clampedEnd - clampedStart, ph - Math.max(1, dpr));
+
+      // Edge lines at start and end
+      ctx.fillStyle = colors.selectionEdge;
+      if (startCanvasX >= 0 && startCanvasX <= pw) {
+        ctx.fillRect(startCanvasX, 0, Math.max(1, Math.round(dpr)), ph);
+      }
+      if (endCanvasX >= 0 && endCanvasX <= pw) {
+        ctx.fillRect(endCanvasX, 0, Math.max(1, Math.round(dpr)), ph);
+      }
+
+      // Labels: page X coordinate at each edge
+      ctx.fillStyle = colors.selectionEdge;
+      ctx.textBaseline = 'top';
+      const labelY = Math.round(2 * dpr);
+
+      // Start label — right-aligned just before the edge line, or left-aligned if at canvas start
+      const startLabelText = String(Math.round(rect.left));
+      if (startCanvasX > 2 * dpr) {
+        ctx.textAlign = 'right';
+        ctx.fillText(startLabelText, startCanvasX - Math.round(dpr), labelY);
+      } else {
+        ctx.textAlign = 'left';
+        ctx.fillText(startLabelText, startCanvasX + Math.round(2 * dpr), labelY);
+      }
+
+      // End label — left-aligned just after the edge line, or right-aligned if at canvas end
+      const endLabelText = String(Math.round(rect.right));
+      if (endCanvasX < pw - 2 * dpr) {
+        ctx.textAlign = 'left';
+        ctx.fillText(endLabelText, endCanvasX + Math.round(2 * dpr), labelY);
+      } else {
+        ctx.textAlign = 'right';
+        ctx.fillText(endLabelText, endCanvasX - Math.round(dpr), labelY);
+      }
+    }
+
     // Blush crosshair line at mouse position
     if (mouseX >= 0) {
       const cx = Math.round(mouseX * dpr);
@@ -286,6 +354,68 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       }
     }
 
+    // Selection range highlights from Measurement Mode
+    ctx.font = `bold ${Math.round(9 * dpr)}px system-ui,-apple-system,sans-serif`;
+    for (const rect of selectedRects) {
+      const startScreenY = rect.top - scrollY;
+      const endScreenY = rect.bottom - scrollY;
+      const startCanvasY = Math.round(startScreenY * dpr);
+      const endCanvasY = Math.round(endScreenY * dpr);
+      const rangeH = endCanvasY - startCanvasY;
+      if (rangeH <= 0 || endCanvasY < 0 || startCanvasY > ph) continue;
+
+      // Filled band across the ruler width (excluding the right border pixel)
+      ctx.fillStyle = colors.selectionFill;
+      const clampedStart = Math.max(0, startCanvasY);
+      const clampedEnd = Math.min(ph, endCanvasY);
+      ctx.fillRect(0, clampedStart, pw - Math.max(1, dpr), clampedEnd - clampedStart);
+
+      // Edge lines at top and bottom
+      ctx.fillStyle = colors.selectionEdge;
+      if (startCanvasY >= 0 && startCanvasY <= ph) {
+        ctx.fillRect(0, startCanvasY, pw, Math.max(1, Math.round(dpr)));
+      }
+      if (endCanvasY >= 0 && endCanvasY <= ph) {
+        ctx.fillRect(0, endCanvasY, pw, Math.max(1, Math.round(dpr)));
+      }
+
+      // Labels: page Y coordinate at each edge, rotated -90°
+      ctx.fillStyle = colors.selectionEdge;
+
+      // Start (top) label
+      const startLabelText = String(Math.round(rect.top));
+      ctx.save();
+      ctx.textBaseline = 'middle';
+      ctx.textAlign = 'center';
+      ctx.translate(Math.round(pw * 0.5), startCanvasY);
+      ctx.rotate(-Math.PI / 2);
+      // Position label above the edge line (to its left when reading the rotated text)
+      if (startCanvasY > 2 * dpr) {
+        ctx.textAlign = 'right';
+        ctx.fillText(startLabelText, -Math.round(dpr), 0);
+      } else {
+        ctx.textAlign = 'left';
+        ctx.fillText(startLabelText, Math.round(2 * dpr), 0);
+      }
+      ctx.restore();
+
+      // End (bottom) label
+      const endLabelText = String(Math.round(rect.bottom));
+      ctx.save();
+      ctx.textBaseline = 'middle';
+      ctx.textAlign = 'center';
+      ctx.translate(Math.round(pw * 0.5), endCanvasY);
+      ctx.rotate(-Math.PI / 2);
+      if (endCanvasY < ph - 2 * dpr) {
+        ctx.textAlign = 'left';
+        ctx.fillText(endLabelText, Math.round(2 * dpr), 0);
+      } else {
+        ctx.textAlign = 'right';
+        ctx.fillText(endLabelText, -Math.round(dpr), 0);
+      }
+      ctx.restore();
+    }
+
     // Blush crosshair line at mouse position
     if (mouseY >= 0) {
       const cy = Math.round(mouseY * dpr);
@@ -341,10 +471,28 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     scheduleRedraw();
   }
 
+  /**
+   * Handles bp-measurement-selection events dispatched by measurement.ts.
+   * Updates the stored selected page-coordinate rects and schedules a redraw.
+   *
+   * @param event - The CustomEvent carrying firstRect and secondRect.
+   */
+  function handleMeasurementSelection(event: Event): void {
+    const { firstRect, secondRect } = (event as CustomEvent).detail as {
+      firstRect: SelectedPageRect | null;
+      secondRect: SelectedPageRect | null;
+    };
+    selectedRects = [];
+    if (firstRect) selectedRects.push(firstRect);
+    if (secondRect) selectedRects.push(secondRect);
+    scheduleRedraw();
+  }
+
   function addEventListeners(): void {
     document.addEventListener('mousemove', handleMouseMove, { passive: true });
     window.addEventListener('scroll', handleScroll, { passive: true });
     window.addEventListener('resize', handleResize, { passive: true });
+    window.addEventListener('bp-measurement-selection', handleMeasurementSelection);
     chrome.storage.onChanged.addListener(handleStorageChange);
   }
 
@@ -352,6 +500,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     document.removeEventListener('mousemove', handleMouseMove);
     window.removeEventListener('scroll', handleScroll);
     window.removeEventListener('resize', handleResize);
+    window.removeEventListener('bp-measurement-selection', handleMeasurementSelection);
     chrome.storage.onChanged.removeListener(handleStorageChange);
   }
 
@@ -410,6 +559,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       removeElements();
       mouseX = -1;
       mouseY = -1;
+      selectedRects = [];
     }
   }
 

--- a/src/scripts/ruler.ts
+++ b/src/scripts/ruler.ts
@@ -27,6 +27,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
   let hCanvas: HTMLCanvasElement | null = null;
   let vCanvas: HTMLCanvasElement | null = null;
   let cornerDiv: HTMLElement | null = null;
+  let selectedElement: HTMLElement | null = null;
+  let selectionHighlight: HTMLElement | null = null;
 
   interface RulerColors {
     bg: string;
@@ -134,6 +136,20 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       cornerDiv.id = 'bp-ruler-corner';
       rulerRoot.appendChild(cornerDiv);
     }
+
+    // Highlight overlay shown over the last clicked element
+    selectionHighlight = rulerRoot.getElementById(
+      'bp-ruler-selection',
+    ) as HTMLElement | null;
+    if (!selectionHighlight) {
+      selectionHighlight = document.createElement('div');
+      selectionHighlight.id = 'bp-ruler-selection';
+      selectionHighlight.style.display = 'none';
+      selectionHighlight.style.pointerEvents = 'none';
+      selectionHighlight.style.boxSizing = 'border-box';
+      selectionHighlight.style.position = 'fixed';
+      rulerRoot.appendChild(selectionHighlight);
+    }
   }
 
   /**
@@ -170,6 +186,25 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     cornerDiv.style.background = colors.bg;
     cornerDiv.style.borderRight = `1px solid ${colors.border}`;
     cornerDiv.style.borderBottom = `1px solid ${colors.border}`;
+  }
+
+  /**
+   * Positions and shows the selection highlight overlay over the given element,
+   * using the ruler's current color palette.
+   *
+   * @param element - The page element to highlight.
+   */
+  function positionSelectionHighlight(element: HTMLElement): void {
+    if (!selectionHighlight) return;
+    const rect = element.getBoundingClientRect();
+    const colors = getColors();
+    selectionHighlight.style.top = `${rect.top}px`;
+    selectionHighlight.style.left = `${rect.left}px`;
+    selectionHighlight.style.width = `${rect.width}px`;
+    selectionHighlight.style.height = `${rect.height}px`;
+    selectionHighlight.style.backgroundColor = colors.selectionFill;
+    selectionHighlight.style.outline = `2px solid ${colors.selectionEdge}`;
+    selectionHighlight.style.display = 'block';
   }
 
   /**
@@ -577,12 +612,14 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
   }
 
   function handleScroll(): void {
+    if (selectedElement) positionSelectionHighlight(selectedElement);
     scheduleRedraw();
   }
 
   function handleResize(): void {
     sizeCanvases();
     applyCornerTheme();
+    if (selectedElement) positionSelectionHighlight(selectedElement);
     scheduleRedraw();
   }
 
@@ -600,6 +637,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     if (areaName !== 'local' || !('darkMode' in changes)) return;
     isDarkMode = !!changes.darkMode.newValue;
     applyCornerTheme();
+    if (selectedElement) positionSelectionHighlight(selectedElement);
     scheduleRedraw();
   }
 
@@ -636,6 +674,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         height: r.height,
       },
     ];
+    selectedElement = target;
+    positionSelectionHighlight(target);
     scheduleRedraw();
   }
 
@@ -711,6 +751,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       mouseX = -1;
       mouseY = -1;
       selectedRects = [];
+      selectedElement = null;
     }
   }
 

--- a/src/scripts/ruler.ts
+++ b/src/scripts/ruler.ts
@@ -32,7 +32,9 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     bg: string;
     border: string;
     tick: string;
+    tickDim: string;
     label: string;
+    labelDim: string;
     crosshair: string;
     selectionFill: string;
     selectionEdge: string;
@@ -49,7 +51,9 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         bg: '#333', // bp-dark-gray
         border: '#555', // mid-gray border
         tick: '#92c7e7', // bp-blue-300
+        tickDim: '#555', // same as border — barely visible inside selection
         label: '#c5e0f2', // bp-blue-200
+        labelDim: 'rgba(197, 224, 242, 0.25)', // bp-blue-200 at 25%
         crosshair: '#aa4465', // bp-blush-600
         selectionFill: 'rgba(146, 199, 231, 0.3)', // bp-blue-300 at 30%
         selectionEdge: '#92c7e7', // bp-blue-300
@@ -59,7 +63,9 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       bg: '#f2f8fd', // bp-blue-50
       border: '#c5e0f2', // bp-blue-200
       tick: '#57a9d9', // bp-blue-400
+      tickDim: '#c5e0f2', // bp-blue-200 — recedes inside selection
       label: '#1d5a87', // bp-blue-700
+      labelDim: 'rgba(29, 90, 135, 0.25)', // bp-blue-700 at 25%
       crosshair: '#aa4465', // bp-blush-600
       selectionFill: 'rgba(42, 125, 181, 0.5)', // bp-blue-500 at 50%
       selectionEdge: '#2a7db5', // bp-blue-500
@@ -170,6 +176,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
    * Draws the horizontal (top) ruler to hCanvas.
    * Shows page-coordinate ticks: minor every 50 px, medium at 100 px, major at 200 px.
    * Labels are rendered at every 200 px mark. A blush vertical line tracks mouseX.
+   * When an element is selected, ticks and labels inside the selection range are dimmed
+   * and regular labels too close to a selection edge label are suppressed.
    */
   function drawHRuler(): void {
     if (!hCanvas) return;
@@ -193,6 +201,19 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     ctx.fillStyle = colors.border;
     ctx.fillRect(0, ph - Math.max(1, dpr), pw, Math.max(1, dpr));
 
+    // Pre-compute selection edges and ranges in canvas space
+    const LABEL_PROXIMITY = Math.round(25 * dpr);
+    const selRangesX = selectedRects.map(r => ({
+      start: Math.round((r.left - scrollX) * dpr),
+      end: Math.round((r.right - scrollX) * dpr),
+    }));
+    const selEdgesX = selRangesX.flatMap(r => [r.start, r.end]);
+
+    const isInsideSelX = (x: number): boolean =>
+      selRangesX.some(r => x > r.start && x < r.end);
+    const tooCloseToSelEdgeX = (x: number): boolean =>
+      selEdgesX.some(ex => Math.abs(x - ex) < LABEL_PROXIMITY);
+
     // Ticks and labels — iterate page coordinates aligned to 50 px grid
     const startPage = Math.floor(scrollX / 50) * 50;
     const endPage = Math.ceil((scrollX + cssW) / 50) * 50;
@@ -208,6 +229,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
 
       const isMajor = page % 200 === 0;
       const isMedium = !isMajor && page % 100 === 0;
+      const inside = isInsideSelX(x);
 
       const tickH = isMajor
         ? Math.round(ph * 0.65)
@@ -215,7 +237,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
           ? Math.round(ph * 0.5)
           : Math.round(ph * 0.3);
 
-      ctx.fillStyle = colors.tick;
+      ctx.fillStyle = inside ? colors.tickDim : colors.tick;
       ctx.fillRect(
         x,
         ph - tickH - Math.max(1, dpr),
@@ -223,19 +245,17 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         tickH,
       );
 
-      if (isMajor) {
-        ctx.fillStyle = colors.label;
+      if (isMajor && !tooCloseToSelEdgeX(x)) {
+        ctx.fillStyle = inside ? colors.labelDim : colors.label;
         ctx.fillText(String(page), x, Math.round(2 * dpr));
       }
     }
 
-    // Selection range highlights from Measurement Mode
+    // Selection range highlights
     ctx.font = `bold ${Math.round(9 * dpr)}px system-ui,-apple-system,sans-serif`;
     for (const rect of selectedRects) {
-      const startScreenX = rect.left - scrollX;
-      const endScreenX = rect.right - scrollX;
-      const startCanvasX = Math.round(startScreenX * dpr);
-      const endCanvasX = Math.round(endScreenX * dpr);
+      const startCanvasX = Math.round((rect.left - scrollX) * dpr);
+      const endCanvasX = Math.round((rect.right - scrollX) * dpr);
       const rangeW = endCanvasX - startCanvasX;
       if (rangeW <= 0 || endCanvasX < 0 || startCanvasX > pw) continue;
 
@@ -301,6 +321,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
    * Draws the vertical (left) ruler to vCanvas.
    * Shows page-coordinate ticks: minor every 50 px, medium at 100 px, major at 200 px.
    * Labels are rotated -90° and rendered at every 200 px mark. A blush horizontal line tracks mouseY.
+   * When an element is selected, ticks and labels inside the selection range are dimmed
+   * and regular labels too close to a selection edge label are suppressed.
    */
   function drawVRuler(): void {
     if (!vCanvas) return;
@@ -323,6 +345,19 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     ctx.fillStyle = colors.border;
     ctx.fillRect(pw - Math.max(1, dpr), 0, Math.max(1, dpr), ph);
 
+    // Pre-compute selection edges and ranges in canvas space
+    const LABEL_PROXIMITY = Math.round(25 * dpr);
+    const selRangesY = selectedRects.map(r => ({
+      start: Math.round((r.top - scrollY) * dpr),
+      end: Math.round((r.bottom - scrollY) * dpr),
+    }));
+    const selEdgesY = selRangesY.flatMap(r => [r.start, r.end]);
+
+    const isInsideSelY = (y: number): boolean =>
+      selRangesY.some(r => y > r.start && y < r.end);
+    const tooCloseToSelEdgeY = (y: number): boolean =>
+      selEdgesY.some(ey => Math.abs(y - ey) < LABEL_PROXIMITY);
+
     const startPage = Math.floor(scrollY / 50) * 50;
     const endPage = Math.ceil((scrollY + cssH) / 50) * 50;
 
@@ -335,6 +370,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
 
       const isMajor = page % 200 === 0;
       const isMedium = !isMajor && page % 100 === 0;
+      const inside = isInsideSelY(y);
 
       const tickW = isMajor
         ? Math.round(pw * 0.65)
@@ -342,7 +378,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
           ? Math.round(pw * 0.5)
           : Math.round(pw * 0.3);
 
-      ctx.fillStyle = colors.tick;
+      ctx.fillStyle = inside ? colors.tickDim : colors.tick;
       ctx.fillRect(
         pw - tickW - Math.max(1, dpr),
         y,
@@ -350,9 +386,9 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         Math.max(1, Math.round(dpr)),
       );
 
-      if (isMajor) {
+      if (isMajor && !tooCloseToSelEdgeY(y)) {
         ctx.save();
-        ctx.fillStyle = colors.label;
+        ctx.fillStyle = inside ? colors.labelDim : colors.label;
         ctx.textBaseline = 'middle';
         ctx.textAlign = 'center';
         // Translate to the tick position and rotate -90° so number reads top-to-bottom from the ruler
@@ -363,13 +399,11 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       }
     }
 
-    // Selection range highlights from Measurement Mode
+    // Selection range highlights
     ctx.font = `bold ${Math.round(9 * dpr)}px system-ui,-apple-system,sans-serif`;
     for (const rect of selectedRects) {
-      const startScreenY = rect.top - scrollY;
-      const endScreenY = rect.bottom - scrollY;
-      const startCanvasY = Math.round(startScreenY * dpr);
-      const endCanvasY = Math.round(endScreenY * dpr);
+      const startCanvasY = Math.round((rect.top - scrollY) * dpr);
+      const endCanvasY = Math.round((rect.bottom - scrollY) * dpr);
       const rangeH = endCanvasY - startCanvasY;
       if (rangeH <= 0 || endCanvasY < 0 || startCanvasY > ph) continue;
 

--- a/src/scripts/ruler.ts
+++ b/src/scripts/ruler.ts
@@ -10,7 +10,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
 
   const RULER_SIZE = 20; // CSS pixels — thickness of each ruler bar
 
-  // Selection highlight state, fed by bp-measurement-selection events
+  // Selection highlight state, maintained from click-based selection
   interface SelectedPageRect {
     left: number;
     right: number;
@@ -27,7 +27,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
   let hCanvas: HTMLCanvasElement | null = null;
   let vCanvas: HTMLCanvasElement | null = null;
   let cornerDiv: HTMLElement | null = null;
-  let selectedElement: HTMLElement | null = null;
+  let selectedElement: Element | null = null;
   let selectionHighlight: HTMLElement | null = null;
 
   interface RulerColors {
@@ -194,7 +194,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
    *
    * @param element - The page element to highlight.
    */
-  function positionSelectionHighlight(element: HTMLElement): void {
+  function positionSelectionHighlight(element: Element): void {
     if (!selectionHighlight) return;
     const rect = element.getBoundingClientRect();
     const colors = getColors();
@@ -649,8 +649,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
    * @param event - The mouse event.
    */
   function handleRulerClick(event: MouseEvent): void {
-    const target = event.target as HTMLElement;
-    if (!target || !(target instanceof HTMLElement)) return;
+    const target = event.target as Element;
+    if (!target || !(target instanceof Element)) return;
 
     // Ignore clicks on the ruler itself and other BP UI containers
     if (
@@ -662,6 +662,11 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       const el = document.getElementById(id);
       if (el && (el === target || el.contains(target))) return;
     }
+
+    // Prevent the click from triggering native element behaviour (navigation,
+    // form submission, button actions, etc.) while ruler mode is active.
+    event.preventDefault();
+    event.stopPropagation();
 
     const r = target.getBoundingClientRect();
     selectedRects = [

--- a/src/scripts/ruler.ts
+++ b/src/scripts/ruler.ts
@@ -255,6 +255,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
 
     // Build axis-aligned bounding boxes (in canvas px) for each selection edge label
     // so regular major labels that would overlap them can be suppressed.
+    // Measure using the bold font that will actually be used when drawing edge labels.
     const GAP_H = Math.round(4 * dpr);
     const HALF_LABEL_H = Math.round(11 * dpr); // approx half-width of a centred major label
     const MIN_OUTSIDE_H = Math.round(20 * dpr);
@@ -262,6 +263,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
       left: number;
       right: number;
     }
+    ctx.font = `bold ${Math.round(9 * dpr)}px system-ui,-apple-system,sans-serif`;
     const selEdgeLabelBoundsX: LabelBoundsH[] = [];
     selRangesX.forEach((r, i) => {
       const src = selectedRects[i];
@@ -299,6 +301,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         b => x + HALF_LABEL_H > b.left && x - HALF_LABEL_H < b.right,
       );
 
+    // Restore regular font for the major tick labels
+    ctx.font = `${Math.round(9 * dpr)}px system-ui,-apple-system,sans-serif`;
     for (let page = startPage; page <= endPage; page += 50) {
       const screen = page - scrollX;
       const x = Math.round(screen * dpr);
@@ -433,11 +437,10 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     const startPage = Math.floor(scrollY / 50) * 50;
     const endPage = Math.ceil((scrollY + cssH) / 50) * 50;
 
-    ctx.font = `${Math.round(9 * dpr)}px system-ui,-apple-system,sans-serif`;
-
     // Build axis-aligned bounding boxes (in canvas px) for each selection edge label
     // in the rotated label's axis (the rotated text reads along the Y axis, so its
     // "width" in the pre-rotation coordinate is what matters for Y-axis collision).
+    // Measure using the bold font that will actually be used when drawing edge labels.
     const GAP_V = Math.round(4 * dpr);
     const HALF_LABEL_V = Math.round(11 * dpr); // approx half of a centred rotated label
     interface LabelBoundsV {
@@ -446,6 +449,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     }
     const selEdgeLabelBoundsY: LabelBoundsV[] = [];
     const MIN_OUTSIDE_V = Math.round(20 * dpr);
+    ctx.font = `bold ${Math.round(9 * dpr)}px system-ui,-apple-system,sans-serif`;
     selRangesY.forEach((r, i) => {
       const src = selectedRects[i];
       const startW = ctx.measureText(String(Math.round(src.top))).width;
@@ -482,6 +486,8 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         b => y + HALF_LABEL_V > b.top && y - HALF_LABEL_V < b.bottom,
       );
 
+    // Restore regular font for the major tick labels
+    ctx.font = `${Math.round(9 * dpr)}px system-ui,-apple-system,sans-serif`;
     for (let page = startPage; page <= endPage; page += 50) {
       const screen = page - scrollY;
       const y = Math.round(screen * dpr);

--- a/src/scripts/ruler.ts
+++ b/src/scripts/ruler.ts
@@ -202,17 +202,13 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     ctx.fillRect(0, ph - Math.max(1, dpr), pw, Math.max(1, dpr));
 
     // Pre-compute selection edges and ranges in canvas space
-    const LABEL_PROXIMITY = Math.round(25 * dpr);
     const selRangesX = selectedRects.map(r => ({
       start: Math.round((r.left - scrollX) * dpr),
       end: Math.round((r.right - scrollX) * dpr),
     }));
-    const selEdgesX = selRangesX.flatMap(r => [r.start, r.end]);
 
     const isInsideSelX = (x: number): boolean =>
       selRangesX.some(r => x > r.start && x < r.end);
-    const tooCloseToSelEdgeX = (x: number): boolean =>
-      selEdgesX.some(ex => Math.abs(x - ex) < LABEL_PROXIMITY);
 
     // Ticks and labels — iterate page coordinates aligned to 50 px grid
     const startPage = Math.floor(scrollX / 50) * 50;
@@ -221,6 +217,52 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     ctx.font = `${Math.round(9 * dpr)}px system-ui,-apple-system,sans-serif`;
     ctx.textBaseline = 'top';
     ctx.textAlign = 'center';
+
+    // Build axis-aligned bounding boxes (in canvas px) for each selection edge label
+    // so regular major labels that would overlap them can be suppressed.
+    const GAP_H = Math.round(4 * dpr);
+    const HALF_LABEL_H = Math.round(11 * dpr); // approx half-width of a centred major label
+    const MIN_OUTSIDE_H = Math.round(20 * dpr);
+    interface LabelBoundsH {
+      left: number;
+      right: number;
+    }
+    const selEdgeLabelBoundsX: LabelBoundsH[] = [];
+    selRangesX.forEach((r, i) => {
+      const src = selectedRects[i];
+      const startW = ctx.measureText(String(Math.round(src.left))).width;
+      const endW = ctx.measureText(String(Math.round(src.right))).width;
+      // Start label: outside means to the left of r.start
+      if (r.start >= MIN_OUTSIDE_H) {
+        selEdgeLabelBoundsX.push({
+          left: r.start - GAP_H - startW,
+          right: r.start - GAP_H,
+        });
+      } else {
+        selEdgeLabelBoundsX.push({
+          left: r.start + GAP_H,
+          right: r.start + GAP_H + startW,
+        });
+      }
+      // End label: outside means to the right of r.end
+      if (r.end <= pw - MIN_OUTSIDE_H) {
+        selEdgeLabelBoundsX.push({
+          left: r.end + GAP_H,
+          right: r.end + GAP_H + endW,
+        });
+      } else {
+        selEdgeLabelBoundsX.push({
+          left: r.end - GAP_H - endW,
+          right: r.end - GAP_H,
+        });
+      }
+    });
+
+    // Returns true if a centred major label at canvas position x would overlap any selection edge label
+    const overlapsSelEdgeLabelX = (x: number): boolean =>
+      selEdgeLabelBoundsX.some(
+        b => x + HALF_LABEL_H > b.left && x - HALF_LABEL_H < b.right,
+      );
 
     for (let page = startPage; page <= endPage; page += 50) {
       const screen = page - scrollX;
@@ -245,7 +287,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         tickH,
       );
 
-      if (isMajor && !tooCloseToSelEdgeX(x)) {
+      if (isMajor && !overlapsSelEdgeLabelX(x)) {
         ctx.fillStyle = inside ? colors.labelDim : colors.label;
         ctx.fillText(String(page), x, Math.round(2 * dpr));
       }
@@ -345,22 +387,65 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
     ctx.fillRect(pw - Math.max(1, dpr), 0, Math.max(1, dpr), ph);
 
     // Pre-compute selection edges and ranges in canvas space
-    const LABEL_PROXIMITY = Math.round(25 * dpr);
     const selRangesY = selectedRects.map(r => ({
       start: Math.round((r.top - scrollY) * dpr),
       end: Math.round((r.bottom - scrollY) * dpr),
     }));
-    const selEdgesY = selRangesY.flatMap(r => [r.start, r.end]);
 
     const isInsideSelY = (y: number): boolean =>
       selRangesY.some(r => y > r.start && y < r.end);
-    const tooCloseToSelEdgeY = (y: number): boolean =>
-      selEdgesY.some(ey => Math.abs(y - ey) < LABEL_PROXIMITY);
 
     const startPage = Math.floor(scrollY / 50) * 50;
     const endPage = Math.ceil((scrollY + cssH) / 50) * 50;
 
     ctx.font = `${Math.round(9 * dpr)}px system-ui,-apple-system,sans-serif`;
+
+    // Build axis-aligned bounding boxes (in canvas px) for each selection edge label
+    // in the rotated label's axis (the rotated text reads along the Y axis, so its
+    // "width" in the pre-rotation coordinate is what matters for Y-axis collision).
+    const GAP_V = Math.round(4 * dpr);
+    const HALF_LABEL_V = Math.round(11 * dpr); // approx half of a centred rotated label
+    interface LabelBoundsV {
+      top: number;
+      bottom: number;
+    }
+    const selEdgeLabelBoundsY: LabelBoundsV[] = [];
+    const MIN_OUTSIDE_V = Math.round(20 * dpr);
+    selRangesY.forEach((r, i) => {
+      const src = selectedRects[i];
+      const startW = ctx.measureText(String(Math.round(src.top))).width;
+      const endW = ctx.measureText(String(Math.round(src.bottom))).width;
+      // Start label: outside means above start line (lower canvas Y)
+      if (r.start >= MIN_OUTSIDE_V) {
+        selEdgeLabelBoundsY.push({
+          top: r.start - GAP_V - startW,
+          bottom: r.start - GAP_V,
+        });
+      } else {
+        selEdgeLabelBoundsY.push({
+          top: r.start + GAP_V,
+          bottom: r.start + GAP_V + startW,
+        });
+      }
+      // End label: outside means below end line (higher canvas Y)
+      if (r.end <= ph - MIN_OUTSIDE_V) {
+        selEdgeLabelBoundsY.push({
+          top: r.end + GAP_V,
+          bottom: r.end + GAP_V + endW,
+        });
+      } else {
+        selEdgeLabelBoundsY.push({
+          top: r.end - GAP_V - endW,
+          bottom: r.end - GAP_V,
+        });
+      }
+    });
+
+    // Returns true if a centred rotated major label at canvas position y would overlap any selection edge label
+    const overlapsSelEdgeLabelY = (y: number): boolean =>
+      selEdgeLabelBoundsY.some(
+        b => y + HALF_LABEL_V > b.top && y - HALF_LABEL_V < b.bottom,
+      );
 
     for (let page = startPage; page <= endPage; page += 50) {
       const screen = page - scrollY;
@@ -385,7 +470,7 @@ import RULER_STYLES from '../styles/components/ruler.shadow.scss';
         Math.max(1, Math.round(dpr)),
       );
 
-      if (isMajor && !tooCloseToSelEdgeY(y)) {
+      if (isMajor && !overlapsSelEdgeLabelY(y)) {
         ctx.save();
         ctx.fillStyle = inside ? colors.labelDim : colors.label;
         ctx.textBaseline = 'middle';


### PR DESCRIPTION
# Overview:

Adds element-bound highlighting to **Ruler Mode** so users can click a page element and see its bounds reflected on both rulers (band + edge labels), with ticks/labels inside the range dimmed.

**Changes:**
- Track a clicked element and render its bounds as a highlighted range on the horizontal/vertical rulers (including edge labels and label-collision suppression).
- Add a fixed-position overlay highlight for the selected element and keep it synced on scroll/resize/theme changes.
- Update feature documentation to describe the new ruler selection behavior.
