### PR TITLE
Add tab-state cleanup and storage migration strategy

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -2,7 +2,6 @@ import {
   DEFAULT_BORDER_SIZE,
   DEFAULT_BORDER_STYLE,
   ICON_PATHS,
-  STORAGE_VERSION,
 } from './scripts/constants';
 import { isRestrictedUrl, isChromeTabClosedError } from './scripts/helpers';
 import Logger from './scripts/utils/logger';
@@ -20,8 +19,8 @@ import { setupCommandListener } from './background/commands';
 
 /**
  * Executed when the extension is installed or updated.
- * Initializes default settings, stamps the storage version, and removes any
- * tab state entries left over from a previous session.
+ * Initializes default settings and removes any tab state entries left over
+ * from a previous session.
  */
 chrome.runtime.onInstalled.addListener(
   async (details: chrome.runtime.InstalledDetails) => {
@@ -43,11 +42,7 @@ chrome.runtime.onInstalled.addListener(
       ]);
 
       // Combine existing settings with defaults (existing takes precedence)
-      const settingsToSet = {
-        ...defaultGlobalSettings,
-        ...existingStorage,
-        storageVersion: STORAGE_VERSION,
-      };
+      const settingsToSet = { ...defaultGlobalSettings, ...existingStorage };
       await chrome.storage.local.set(settingsToSet);
 
       // Remove any tab state entries that were left behind by the previous session.

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,11 +2,15 @@ import {
   DEFAULT_BORDER_SIZE,
   DEFAULT_BORDER_STYLE,
   ICON_PATHS,
+  STORAGE_VERSION,
 } from './scripts/constants';
 import { isRestrictedUrl, isChromeTabClosedError } from './scripts/helpers';
 import Logger from './scripts/utils/logger';
 import { handleTabStateChange } from './background/extension-ui';
-import { clearTabStateCache } from './background/tab-state';
+import {
+  clearTabStateCache,
+  cleanupOrphanedTabStates,
+} from './background/tab-state';
 import { setupMessageListener } from './background/message-handlers';
 import {
   setupContextMenu,
@@ -16,7 +20,8 @@ import { setupCommandListener } from './background/commands';
 
 /**
  * Executed when the extension is installed or updated.
- * Initializes default settings and potentially clears old per-tab state keys.
+ * Initializes default settings, stamps the storage version, and removes any
+ * tab state entries left over from a previous session.
  */
 chrome.runtime.onInstalled.addListener(
   async (details: chrome.runtime.InstalledDetails) => {
@@ -37,13 +42,16 @@ chrome.runtime.onInstalled.addListener(
         'darkMode',
       ]);
 
-      // Clear all storage data
-      // await chrome.storage.local.clear(); // Commenting this out to preserve settings on update
-
       // Combine existing settings with defaults (existing takes precedence)
-      const settingsToSet = { ...defaultGlobalSettings, ...existingStorage };
-      // Set the default settings in storage
+      const settingsToSet = {
+        ...defaultGlobalSettings,
+        ...existingStorage,
+        storageVersion: STORAGE_VERSION,
+      };
       await chrome.storage.local.set(settingsToSet);
+
+      // Remove any tab state entries that were left behind by the previous session.
+      await cleanupOrphanedTabStates();
     } catch (error) {
       Logger.error('Error during onInstalled:', error);
     }
@@ -52,6 +60,16 @@ chrome.runtime.onInstalled.addListener(
     setupContextMenu();
   },
 );
+
+/**
+ * Executed when the browser starts up (after a previous normal shutdown).
+ * Cleans up any tab state entries that were not removed when the browser last
+ * closed (e.g. after a crash where onRemoved events were not fired).
+ */
+chrome.runtime.onStartup.addListener(async () => {
+  Logger.info('onStartup: cleaning up orphaned tab states');
+  await cleanupOrphanedTabStates();
+});
 
 /**
  * Injects the border script when a tab is updated (when a page loads or reloads).

--- a/src/background/tab-state.ts
+++ b/src/background/tab-state.ts
@@ -9,6 +9,9 @@ const cachedTabStates: Record<string, TabState> = {}; // tabId: TabState
  * Retrieves the extension state for the specified tab ID.
  * Checks cache first, then storage. Updates cache from storage.
  *
+ * Merges stored state with DEFAULT_TAB_STATE so that any fields added in
+ * future versions are always present (migration-safe forward compatibility).
+ *
  * @param tabId - The ID of the tab to retrieve the state for.
  * @returns The state of the extension for the specified tab ID.
  */
@@ -23,7 +26,9 @@ export async function getTabState(tabId: number): Promise<TabState> {
     const storedData = await chrome.storage.local.get(tabIdString);
     const tabState = storedData?.[tabIdString];
 
-    cachedTabStates[tabIdString] = tabState ?? { ...DEFAULT_TAB_STATE };
+    // Always spread DEFAULT_TAB_STATE first so that any fields added in future
+    // schema versions are present even when reading old stored data.
+    cachedTabStates[tabIdString] = { ...DEFAULT_TAB_STATE, ...(tabState ?? {}) };
     return cachedTabStates[tabIdString];
   } catch (error) {
     Logger.error(
@@ -69,4 +74,41 @@ export async function setTabState({
  */
 export function clearTabStateCache(tabId: number): void {
   delete cachedTabStates[tabId.toString()];
+}
+
+/**
+ * Removes stored state for tabs that are no longer open.
+ *
+ * Called on browser startup to evict entries left behind by a previous
+ * session where the browser (or extension) terminated without firing
+ * `chrome.tabs.onRemoved` for every tab.
+ */
+export async function cleanupOrphanedTabStates(): Promise<void> {
+  try {
+    const openTabs = await chrome.tabs.query({});
+    const openTabIds = new Set(
+      openTabs.map(tab => tab.id?.toString()).filter(Boolean),
+    );
+
+    const allStorage = await chrome.storage.local.get(null);
+
+    // Tab state keys are purely numeric strings.
+    const orphanedKeys = Object.keys(allStorage).filter(
+      key => /^\d+$/.test(key) && !openTabIds.has(key),
+    );
+
+    if (orphanedKeys.length === 0) return;
+
+    await chrome.storage.local.remove(orphanedKeys);
+    orphanedKeys.forEach(key => {
+      delete cachedTabStates[key];
+    });
+
+    Logger.info(
+      `Cleaned up ${orphanedKeys.length} orphaned tab state(s):`,
+      orphanedKeys,
+    );
+  } catch (error) {
+    Logger.error('Error cleaning up orphaned tab states:', error);
+  }
 }

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -1,12 +1,6 @@
 /** Default locale for the extension. */
 export const DEFAULT_LOCALE = 'en';
 
-/**
- * Storage schema version. Increment this whenever TabState shape changes
- * so that migration logic can transform old stored data to the new shape.
- */
-export const STORAGE_VERSION = 1;
-
 export const DEFAULT_BORDER_SIZE = 1;
 export const DEFAULT_BORDER_STYLE = 'solid';
 export const DEFAULT_TAB_STATE = {

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -1,6 +1,12 @@
 /** Default locale for the extension. */
 export const DEFAULT_LOCALE = 'en';
 
+/**
+ * Storage schema version. Increment this whenever TabState shape changes
+ * so that migration logic can transform old stored data to the new shape.
+ */
+export const STORAGE_VERSION = 1;
+
 export const DEFAULT_BORDER_SIZE = 1;
 export const DEFAULT_BORDER_STYLE = 'solid';
 export const DEFAULT_TAB_STATE = {

--- a/tests/src/background/tab-state.test.ts
+++ b/tests/src/background/tab-state.test.ts
@@ -1,0 +1,165 @@
+import { DEFAULT_TAB_STATE } from 'scripts/constants';
+import {
+  getTabState,
+  setTabState,
+  clearTabStateCache,
+  cleanupOrphanedTabStates,
+} from 'background/tab-state';
+
+// ---------------------------------------------------------------------------
+// Chrome API stub
+// ---------------------------------------------------------------------------
+
+const storageData: Record<string, unknown> = {};
+
+const chromeMock = {
+  storage: {
+    local: {
+      get: jest.fn(async (keys: string | string[] | null) => {
+        if (keys === null) return { ...storageData };
+        const keyList = Array.isArray(keys) ? keys : [keys];
+        return Object.fromEntries(
+          keyList
+            .filter(k => k in storageData)
+            .map(k => [k, storageData[k]]),
+        );
+      }),
+      set: jest.fn(async (items: Record<string, unknown>) => {
+        Object.assign(storageData, items);
+      }),
+      remove: jest.fn(async (keys: string | string[]) => {
+        const keyList = Array.isArray(keys) ? keys : [keys];
+        keyList.forEach(k => {
+          delete storageData[k];
+        });
+      }),
+    },
+  },
+  tabs: {
+    query: jest.fn(async () => [] as chrome.tabs.Tab[]),
+  },
+};
+
+(global as Record<string, unknown>).chrome = chromeMock;
+
+// ---------------------------------------------------------------------------
+// Reset storage and mocks before each test.
+// Each test uses a unique tab ID so the module-level cache never collides.
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  Object.keys(storageData).forEach(k => delete storageData[k]);
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// getTabState — migration-safe defaults
+// ---------------------------------------------------------------------------
+
+describe('getTabState', () => {
+  it('returns DEFAULT_TAB_STATE when no stored data exists', async () => {
+    const state = await getTabState(1);
+    expect(state).toEqual(DEFAULT_TAB_STATE);
+  });
+
+  it('returns stored values when they exist', async () => {
+    storageData['42'] = { ...DEFAULT_TAB_STATE, borderMode: true };
+    const state = await getTabState(42);
+    expect(state.borderMode).toBe(true);
+  });
+
+  it('fills missing fields with defaults (forward-compatibility migration)', async () => {
+    // Simulate old stored data missing a field added in a later schema version.
+    storageData['7'] = { borderMode: true, inspectorMode: false };
+    const state = await getTabState(7);
+    expect(state.borderMode).toBe(true);
+    expect(state.measurementMode).toBe(DEFAULT_TAB_STATE.measurementMode);
+    expect(state.rulerMode).toBe(DEFAULT_TAB_STATE.rulerMode);
+  });
+
+  it('returns from cache on second call without hitting storage again', async () => {
+    storageData['3'] = { ...DEFAULT_TAB_STATE, borderMode: true };
+    await getTabState(3);
+    await getTabState(3);
+    expect(chromeMock.storage.local.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('cache is cleared by clearTabStateCache, forcing a fresh storage read', async () => {
+    storageData['5'] = { ...DEFAULT_TAB_STATE, borderMode: true };
+    await getTabState(5);
+    clearTabStateCache(5);
+    // Update stored value — must be reflected after cache eviction
+    storageData['5'] = { ...DEFAULT_TAB_STATE, borderMode: false };
+    const state = await getTabState(5);
+    expect(state.borderMode).toBe(false);
+    expect(chromeMock.storage.local.get).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setTabState
+// ---------------------------------------------------------------------------
+
+describe('setTabState', () => {
+  it('merges partial state with existing state', async () => {
+    storageData['10'] = { ...DEFAULT_TAB_STATE, borderMode: true };
+    await setTabState({ tabId: 10, states: { inspectorMode: true } });
+    const state = await getTabState(10);
+    expect(state.borderMode).toBe(true);
+    expect(state.inspectorMode).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanupOrphanedTabStates
+// ---------------------------------------------------------------------------
+
+describe('cleanupOrphanedTabStates', () => {
+  it('removes stored tab keys that are not in the open-tab list', async () => {
+    storageData['100'] = { ...DEFAULT_TAB_STATE };
+    storageData['101'] = { ...DEFAULT_TAB_STATE, borderMode: true };
+    storageData['borderSize'] = 2; // global setting — must NOT be removed
+
+    // Only tab 101 is open
+    chromeMock.tabs.query.mockResolvedValueOnce([{ id: 101 }]);
+    await cleanupOrphanedTabStates();
+
+    expect(chromeMock.storage.local.remove).toHaveBeenCalledWith(['100']);
+    expect(storageData['borderSize']).toBe(2); // global setting preserved
+    expect(storageData['101']).toBeDefined();   // open-tab state preserved
+  });
+
+  it('does not call remove when there are no orphaned entries', async () => {
+    storageData['200'] = { ...DEFAULT_TAB_STATE };
+    chromeMock.tabs.query.mockResolvedValueOnce([{ id: 200 }]);
+
+    await cleanupOrphanedTabStates();
+
+    expect(chromeMock.storage.local.remove).not.toHaveBeenCalled();
+  });
+
+  it('clears orphaned keys from the in-memory cache', async () => {
+    storageData['300'] = { ...DEFAULT_TAB_STATE, borderMode: true };
+    await getTabState(300); // warm the cache
+
+    chromeMock.tabs.query.mockResolvedValueOnce([]); // tab 300 no longer open
+    await cleanupOrphanedTabStates();
+
+    jest.clearAllMocks();
+    storageData['300'] = { ...DEFAULT_TAB_STATE, borderMode: false };
+    const state = await getTabState(300);
+    // If cache was cleared, storage must have been read again
+    expect(chromeMock.storage.local.get).toHaveBeenCalledTimes(1);
+    expect(state.borderMode).toBe(false);
+  });
+
+  it('ignores non-numeric storage keys (global settings)', async () => {
+    storageData['storageVersion'] = 1;
+    storageData['borderStyle'] = 'dashed';
+    chromeMock.tabs.query.mockResolvedValueOnce([]);
+
+    await cleanupOrphanedTabStates();
+
+    expect(chromeMock.storage.local.remove).not.toHaveBeenCalled();
+  });
+});

--- a/tests/src/background/tab-state.test.ts
+++ b/tests/src/background/tab-state.test.ts
@@ -40,7 +40,7 @@ const chromeMock = {
   },
 };
 
-(global as Record<string, unknown>).chrome = chromeMock;
+(globalThis as Record<string, unknown>).chrome = chromeMock;
 
 // ---------------------------------------------------------------------------
 // Reset storage and mocks before each test.
@@ -121,7 +121,7 @@ describe('cleanupOrphanedTabStates', () => {
     storageData['borderSize'] = 2; // global setting — must NOT be removed
 
     // Only tab 101 is open
-    chromeMock.tabs.query.mockResolvedValueOnce([{ id: 101 }]);
+    chromeMock.tabs.query.mockResolvedValueOnce([{ id: 101 } as chrome.tabs.Tab]);
     await cleanupOrphanedTabStates();
 
     expect(chromeMock.storage.local.remove).toHaveBeenCalledWith(['100']);
@@ -131,7 +131,7 @@ describe('cleanupOrphanedTabStates', () => {
 
   it('does not call remove when there are no orphaned entries', async () => {
     storageData['200'] = { ...DEFAULT_TAB_STATE };
-    chromeMock.tabs.query.mockResolvedValueOnce([{ id: 200 }]);
+    chromeMock.tabs.query.mockResolvedValueOnce([{ id: 200 } as chrome.tabs.Tab]);
 
     await cleanupOrphanedTabStates();
 


### PR DESCRIPTION
# Overview:

Adds lifecycle cleanup for per-tab state stored in `chrome.storage.local` and introduces a (currently unused) storage schema version constant to support future migrations.

**Changes:**
- Make `getTabState` merge stored state with `DEFAULT_TAB_STATE` for forward-compatible defaults.
- Add `cleanupOrphanedTabStates()` and run it on extension install/update and browser startup to remove stale numeric tabId keys.
- Add unit tests covering cache behavior, default-merging behavior, and orphan cleanup.

Fixes #120 
