### PR TITLE
Optimize build pipeline — 9s → 1.1s (88% faster)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ Thumbs.db
 
 # Hide optimization reports
 bundle-report.html
+
+# Build cache (vendor CSS, etc.)
+.build-cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Reworked the build process for faster builds and better optimization (dropping total build time from ~9s to ~1.1s).
+
 ## [1.7.1] - 2026-04-02
 
 ### Added

--- a/landing/changelog.html
+++ b/landing/changelog.html
@@ -55,6 +55,14 @@
       <p>
         All notable changes to this project will be documented in this file.
       </p>
+      <h2>[Unreleased]</h2>
+      <h3>Changed</h3>
+      <ul>
+        <li>
+          Reworked the build process for faster builds and better optimization
+          (dropping total build time from ~9s to ~1.1s).
+        </li>
+      </ul>
       <h2>[1.7.1] - 2026-04-02</h2>
       <h3>Added</h3>
       <ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "antd": "^6.3.1",
+        "antd": "^6.3.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -34,6 +34,7 @@
         "babel-plugin-import": "^1.13.8",
         "baseline-browser-mapping": "^2.10.15",
         "cssnano": "^7.1.1",
+        "esbuild-sass-plugin": "^3.7.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
@@ -104,9 +105,9 @@
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.0.tgz",
-      "integrity": "sha512-KrWMu1fIg3w/1F2zfn+JlfNDU8dDqILfA5Tg85iqs1lf8ooyGlbkA+TkwfOKKgqpUmAiRY1PTFpuOU2DAIgSUg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.1.tgz",
+      "integrity": "sha512-AMT4N2y++TZETNHiM77fs4a0uPVCJGuL5MTonk13Pvv7UN7sID1cNEZOc1qNqx6zLKAOilTEFAdAoAFKa0U//Q==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^8.0.0",
@@ -2048,6 +2049,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -3672,9 +3681,9 @@
       }
     },
     "node_modules/@rc-component/form": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.6.2.tgz",
-      "integrity": "sha512-OgIn2RAoaSBqaIgzJf/X6iflIa9LpTozci1lagLBdURDFhGA370v0+T0tXxOi8YShMjTha531sFhwtnrv+EJaQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.8.0.tgz",
+      "integrity": "sha512-eUD5KKYnIZWmJwRA0vnyO/ovYUfHGU1svydY1OrqU5fw8Oz9Tdqvxvrlh0wl6xI/EW69dT7II49xpgOWzK3T5A==",
       "license": "MIT",
       "dependencies": {
         "@rc-component/async-validator": "^5.1.0",
@@ -3690,14 +3699,14 @@
       }
     },
     "node_modules/@rc-component/image": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.6.0.tgz",
-      "integrity": "sha512-tSfn2ZE/oP082g4QIOxeehkmgnXB7R+5AFj/lIFr4k7pEuxHBdyGIq9axoCY9qea8NN0DY6p4IB/F07tLqaT5A==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.8.1.tgz",
+      "integrity": "sha512-JfPCijmMl+EaMvbftsEs/4VHmTyJKsZBh5ujFowSA45i9NTVYS1vuHtgpVV/QrGa27kXwbVOZriffCe/PNKuMw==",
       "license": "MIT",
       "dependencies": {
         "@rc-component/motion": "^1.0.0",
         "@rc-component/portal": "^2.1.2",
-        "@rc-component/util": "^1.3.0",
+        "@rc-component/util": "^1.10.1",
         "clsx": "^2.1.1"
       },
       "peerDependencies": {
@@ -3782,9 +3791,9 @@
       }
     },
     "node_modules/@rc-component/motion": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.1.tgz",
-      "integrity": "sha512-Wo1mkd0tCcHtvYvpPOmlYJz546z16qlsiwaygmW7NPJpOZOF9GBjhGzdzZSsC2lEJ1IUkWLF4gMHlRA1aSA+Yw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.2.tgz",
+      "integrity": "sha512-itfd+GztzJYAb04Z4RkEub1TbJAfZc2Iuy8p44U44xD1F5+fNYFKI3897ijlbIyfvXkTmMm+KGcjkQQGMHywEQ==",
       "license": "MIT",
       "dependencies": {
         "@rc-component/util": "^1.2.0",
@@ -3860,9 +3869,9 @@
       }
     },
     "node_modules/@rc-component/picker": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.9.0.tgz",
-      "integrity": "sha512-OLisdk8AWVCG9goBU1dWzuH5QlBQk8jktmQ6p0/IyBFwdKGwyIZOSjnBYo8hooHiTdl0lU+wGf/OfMtVBw02KQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.9.1.tgz",
+      "integrity": "sha512-9FBYYsvH3HMLICaPDA/1Th5FLaDkFa7qAtangIdlhKb3ZALaR745e9PsOhheJb6asS4QXc12ffiAcjdkZ4C5/g==",
       "license": "MIT",
       "dependencies": {
         "@rc-component/overflow": "^1.0.0",
@@ -3962,9 +3971,9 @@
       }
     },
     "node_modules/@rc-component/resize-observer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.1.tgz",
-      "integrity": "sha512-NfXXMmiR+SmUuKE1NwJESzEUYUFWIDUn2uXpxCTOLwiRUUakd62DRNFjRJArgzyFW8S5rsL4aX5XlyIXyC/vRA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.2.tgz",
+      "integrity": "sha512-t/Bb0W8uvL4PYKAB3YcChC+DlHh0Wt5kM7q/J+0qpVEUMLe7Hk5zuvc9km0hMnTFPSx5Z7Wu/fzCLN6erVLE8Q==",
       "license": "MIT",
       "dependencies": {
         "@rc-component/util": "^1.2.0"
@@ -3991,9 +4000,9 @@
       }
     },
     "node_modules/@rc-component/select": {
-      "version": "1.6.14",
-      "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.14.tgz",
-      "integrity": "sha512-T1IWeLlSas7Z/igZtPtJ/bweCxMMkXIGKQBtnigK+I/n1AVNjCs+ZdL3Fj42mq3uqm4sd1uzeQLZkdCqR26ADw==",
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.15.tgz",
+      "integrity": "sha512-SyVCWnqxCQZZcQvQJ/CxSjx2bGma6ds/HtnpkIfZVnt6RoEgbqUmHgD6vrzNarNXwbLXerwVzWwq8F3d1sst7g==",
       "license": "MIT",
       "dependencies": {
         "@rc-component/overflow": "^1.0.0",
@@ -4150,9 +4159,9 @@
       }
     },
     "node_modules/@rc-component/tree": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.3.tgz",
-      "integrity": "sha512-mG8hF2ogQcKaEpfyxzPvMWqqkptofd7Sf+YiXOpPzuXLTLwNKfLDJtysc1/oybopbnzxNqWh2Vgwi+GYwNIb7w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.4.tgz",
+      "integrity": "sha512-5Gli43+m4R7NhpYYz3Z61I6LOw9yI6CNChxgVtvrO6xB1qML7iE6QMLVMB3+FTjo2yF6uFdAHtqWPECz/zbX5w==",
       "license": "MIT",
       "dependencies": {
         "@rc-component/motion": "^1.0.0",
@@ -4219,9 +4228,9 @@
       }
     },
     "node_modules/@rc-component/util": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.9.0.tgz",
-      "integrity": "sha512-5uW6AfhIigCWeEQDthTozlxiT4Prn6xYQWeO0xokjcaa186OtwPRHBZJ2o0T0FhbjGhZ3vXdbkv0sx3gAYW7Vg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.10.1.tgz",
+      "integrity": "sha512-q++9S6rUa5Idb/xIBNz6jtvumw5+O5YV5V0g4iK9mn9jWs4oGJheE3ZN1kAnE723AXyaD8v95yeOASmdk8Jnng==",
       "license": "MIT",
       "dependencies": {
         "is-mobile": "^5.0.0",
@@ -5398,42 +5407,42 @@
       }
     },
     "node_modules/antd": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-6.3.1.tgz",
-      "integrity": "sha512-8pRjvxitZFyrYAtgwml93Km7fCXjw9IeqlmzpIsusRsmO3eWFVrOMum6+0TsGCtR/WrXVnPwfsgrFg3ChzGCeA==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-6.3.5.tgz",
+      "integrity": "sha512-8BPz9lpZWQm42PTx7yL4KxWAotVuqINiKcoYRcLtdd5BFmAcAZicVyFTnBJyRDlzGZFZeRW3foGu6jXYFnej6Q==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^8.0.1",
-        "@ant-design/cssinjs": "^2.1.0",
-        "@ant-design/cssinjs-utils": "^2.1.1",
+        "@ant-design/cssinjs": "^2.1.2",
+        "@ant-design/cssinjs-utils": "^2.1.2",
         "@ant-design/fast-color": "^3.0.1",
-        "@ant-design/icons": "^6.1.0",
+        "@ant-design/icons": "^6.1.1",
         "@ant-design/react-slick": "~2.0.0",
         "@babel/runtime": "^7.28.4",
         "@rc-component/cascader": "~1.14.0",
         "@rc-component/checkbox": "~2.0.0",
         "@rc-component/collapse": "~1.2.0",
-        "@rc-component/color-picker": "~3.1.0",
+        "@rc-component/color-picker": "~3.1.1",
         "@rc-component/dialog": "~1.8.4",
         "@rc-component/drawer": "~1.4.2",
         "@rc-component/dropdown": "~1.0.2",
-        "@rc-component/form": "~1.6.2",
-        "@rc-component/image": "~1.6.0",
+        "@rc-component/form": "~1.8.0",
+        "@rc-component/image": "~1.8.0",
         "@rc-component/input": "~1.1.2",
         "@rc-component/input-number": "~1.6.2",
         "@rc-component/mentions": "~1.6.0",
         "@rc-component/menu": "~1.2.0",
-        "@rc-component/motion": "^1.3.1",
+        "@rc-component/motion": "^1.3.2",
         "@rc-component/mutate-observer": "^2.0.1",
         "@rc-component/notification": "~1.2.0",
         "@rc-component/pagination": "~1.2.0",
-        "@rc-component/picker": "~1.9.0",
+        "@rc-component/picker": "~1.9.1",
         "@rc-component/progress": "~1.0.2",
         "@rc-component/qrcode": "~1.1.1",
         "@rc-component/rate": "~1.0.1",
-        "@rc-component/resize-observer": "^1.1.1",
+        "@rc-component/resize-observer": "^1.1.2",
         "@rc-component/segmented": "~1.3.0",
-        "@rc-component/select": "~1.6.12",
+        "@rc-component/select": "~1.6.15",
         "@rc-component/slider": "~1.0.1",
         "@rc-component/steps": "~1.2.2",
         "@rc-component/switch": "~1.0.3",
@@ -5442,11 +5451,11 @@
         "@rc-component/textarea": "~1.1.2",
         "@rc-component/tooltip": "~1.4.0",
         "@rc-component/tour": "~2.3.0",
-        "@rc-component/tree": "~1.2.3",
+        "@rc-component/tree": "~1.2.4",
         "@rc-component/tree-select": "~1.8.0",
         "@rc-component/trigger": "^3.9.0",
         "@rc-component/upload": "~1.1.0",
-        "@rc-component/util": "^1.9.0",
+        "@rc-component/util": "^1.10.0",
         "clsx": "^2.1.1",
         "dayjs": "^1.11.11",
         "scroll-into-view-if-needed": "^3.1.0",
@@ -6180,6 +6189,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorjs.io": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
+      "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/commander": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
@@ -6527,9 +6544,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.19",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -6806,6 +6823,21 @@
         "@esbuild/win32-arm64": "0.28.0",
         "@esbuild/win32-ia32": "0.28.0",
         "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/esbuild-sass-plugin": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-3.7.0.tgz",
+      "integrity": "sha512-vxNSXFx3/0ZFApKo9036ek2iRfsT+yVO99qIYqa+JaDSuJuId2/N4s1TY+xfK+5LRpAMQkfdBVUTxb/1r2bq1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.22.11",
+        "sass": "^1.97.3"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.27.3",
+        "sass-embedded": "^1.97.3"
       }
     },
     "node_modules/escalade": {
@@ -10202,13 +10234,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -11169,6 +11201,17 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -11205,14 +11248,14 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.93.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
-      "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+      "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
@@ -11223,6 +11266,390 @@
       },
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
+      }
+    },
+    "node_modules/sass-embedded": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.99.0.tgz",
+      "integrity": "sha512-gF/juR1aX02lZHkvwxdF80SapkQeg2fetoDF6gIQkNbSw5YEUFspMkyGTjPjgZSgIHuZpy+Wz4PlebKnLXMjdg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.5.0",
+        "colorjs.io": "^0.5.0",
+        "immutable": "^5.1.5",
+        "rxjs": "^7.4.0",
+        "supports-color": "^8.1.1",
+        "sync-child-process": "^1.0.2",
+        "varint": "^6.0.0"
+      },
+      "bin": {
+        "sass": "dist/bin/sass.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "sass-embedded-all-unknown": "1.99.0",
+        "sass-embedded-android-arm": "1.99.0",
+        "sass-embedded-android-arm64": "1.99.0",
+        "sass-embedded-android-riscv64": "1.99.0",
+        "sass-embedded-android-x64": "1.99.0",
+        "sass-embedded-darwin-arm64": "1.99.0",
+        "sass-embedded-darwin-x64": "1.99.0",
+        "sass-embedded-linux-arm": "1.99.0",
+        "sass-embedded-linux-arm64": "1.99.0",
+        "sass-embedded-linux-musl-arm": "1.99.0",
+        "sass-embedded-linux-musl-arm64": "1.99.0",
+        "sass-embedded-linux-musl-riscv64": "1.99.0",
+        "sass-embedded-linux-musl-x64": "1.99.0",
+        "sass-embedded-linux-riscv64": "1.99.0",
+        "sass-embedded-linux-x64": "1.99.0",
+        "sass-embedded-unknown-all": "1.99.0",
+        "sass-embedded-win32-arm64": "1.99.0",
+        "sass-embedded-win32-x64": "1.99.0"
+      }
+    },
+    "node_modules/sass-embedded-all-unknown": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.99.0.tgz",
+      "integrity": "sha512-qPIRG8Uhjo6/OKyAKixTnwMliTz+t9K6Duk0mx5z+K7n0Ts38NSJz2sjDnc7cA/8V9Lb3q09H38dZ1CLwD+ssw==",
+      "cpu": [
+        "!arm",
+        "!arm64",
+        "!riscv64",
+        "!x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "sass": "1.99.0"
+      }
+    },
+    "node_modules/sass-embedded-android-arm": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.99.0.tgz",
+      "integrity": "sha512-EHvJ0C7/VuP78Qr6f8gIUVUmCqIorEQpw2yp3cs3SMg02ZuumlhjXvkTcFBxHmFdFR23vTNk1WnhY6QSeV1nFQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-arm64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.99.0.tgz",
+      "integrity": "sha512-fNHhdnP23yqqieCbAdym4N47AleSwjbNt6OYIYx4DdACGdtERjQB4iOX/TaKsW034MupfF7SjnAAK8w7Ptldtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-riscv64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.99.0.tgz",
+      "integrity": "sha512-4zqDFRvgGDTL5vTHuIhRxUpXFoh0Cy7Gm5Ywk19ASd8Settmd14YdPRZPmMxfgS1GH292PofV1fq1ifiSEJWBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-x64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.99.0.tgz",
+      "integrity": "sha512-Uk53k/dGYt04RjOL4gFjZ0Z9DH9DKh8IA8WsXUkNqsxerAygoy3zqRBS2zngfE9K2jiOM87q+1R1p87ory9oQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-arm64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.99.0.tgz",
+      "integrity": "sha512-u61/7U3IGLqoO6gL+AHeiAtlTPFwJK1+964U8gp45ZN0hzh1yrARf5O1mivXv8NnNgJvbG2wWJbiNZP0lG/lTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-x64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.99.0.tgz",
+      "integrity": "sha512-j/kkk/NcXdIameLezSfXjgCiBkVcA+G60AXrX768/3g0miK1g7M9dj7xOhCb1i7/wQeiEI3rw2LLuO63xRIn4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.99.0.tgz",
+      "integrity": "sha512-d4IjJZrX2+AwB2YCy1JySwdptJECNP/WfAQLUl8txI3ka8/d3TUI155GtelnoZUkio211PwIeFvvAeZ9RXPQnw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.99.0.tgz",
+      "integrity": "sha512-btNcFpItcB56L40n8hDeL7sRSMLDXQ56nB5h2deddJx1n60rpKSElJmkaDGHtpkrY+CTtDRV0FZDjHeTJddYew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-arm": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.99.0.tgz",
+      "integrity": "sha512-2gvHOupgIw3ytatXT4nFUow71LFbuOZPEwG+HUzcNQDH8ue4Ez8cr03vsv5MDv3lIjOKcXwDvWD980t18MwkoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-arm64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.99.0.tgz",
+      "integrity": "sha512-Hi2bt/IrM5P4FBKz6EcHAlniwfpoz9mnTdvSd58y+avA3SANM76upIkAdSayA8ZGwyL3gZokru1AKDPF9lJDNw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-riscv64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.99.0.tgz",
+      "integrity": "sha512-mKqGvVaJ9rHMqyZsF0kikQe4NO0f4osb67+X6nLhBiVDKvyazQHJ3zJQreNefIE36yL2sjHIclSB//MprzaQDg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-x64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.99.0.tgz",
+      "integrity": "sha512-huhgOMmOc30r7CH7qbRbT9LerSEGSnWuS4CYNOskr9BvNeQp4dIneFufNRGZ7hkOAxUM8DglxIZJN/cyAT95Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-riscv64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.99.0.tgz",
+      "integrity": "sha512-mevFPIFAVhrH90THifxLfOntFmHtcEKOcdWnep2gJ0X4DVva4AiVIRlQe/7w9JFx5+gnDRE1oaJJkzuFUuYZsA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-x64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.99.0.tgz",
+      "integrity": "sha512-9k7IkULqIZdCIVt4Mboryt6vN8Mjmm3EhI1P3mClU5y5i3wLK5ExC3cbVWk047KsID/fvB1RLslqghXJx5BoxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-unknown-all": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.99.0.tgz",
+      "integrity": "sha512-P7MxiUtL/XzGo3PX0CaB8lNNEFLQWKikPA8pbKytx9ZCLZSDkt2NJcdAbblB/sqMs4AV3EK2NadV8rI/diq3xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "!android",
+        "!darwin",
+        "!linux",
+        "!win32"
+      ],
+      "peer": true,
+      "dependencies": {
+        "sass": "1.99.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-arm64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.99.0.tgz",
+      "integrity": "sha512-8whpsW7S+uO8QApKfQuc36m3P9EISzbVZOgC79goob4qGy09u8Gz/rYvw8h1prJDSjltpHGhOzBE6LDz7WvzVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-x64": {
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.99.0.tgz",
+      "integrity": "sha512-ipuOv1R2K4MHeuCEAZGpuUbAgma4gb0sdacyrTjJtMOy/OY9UvWfVlwErdB09KIkp4fPDpQJDJfvYN6bC8jeNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/sax": {
@@ -11693,6 +12120,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sync-child-process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
+      "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "sync-message-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/sync-message-port": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.2.0.tgz",
+      "integrity": "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -11909,8 +12361,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -12114,6 +12565,14 @@
       "engines": {
         "node": ">=10.12.0"
       }
+    },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "prettier": "^3.7.3",
         "rollup": "^4.50.1",
         "rollup-plugin-copy": "^3.5.0",
+        "rollup-plugin-esbuild": "^6.2.1",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-visualizer": "^6.0.3",
         "sass": "^1.92.1",
@@ -2207,6 +2208,474 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -6289,6 +6758,56 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -6661,6 +7180,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -8700,6 +9232,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9706,6 +10245,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -9777,6 +10326,26 @@
       },
       "engines": {
         "node": ">=8.3"
+      }
+    },
+    "node_modules/rollup-plugin-esbuild": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-esbuild/-/rollup-plugin-esbuild-6.2.1.tgz",
+      "integrity": "sha512-jTNOMGoMRhs0JuueJrJqbW8tOwxumaWYq+V5i+PD+8ecSCVkuX27tGW7BXqDgoULQ55rO7IdNxPcnsWtshz3AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.6.0",
+        "get-tsconfig": "^4.10.0",
+        "unplugin-utils": "^0.2.4"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18.0",
+        "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/rollup-plugin-postcss": {
@@ -11439,6 +12008,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unplugin-utils": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.5.tgz",
+      "integrity": "sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
       }
     },
     "node_modules/unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "compress:dist": "node scripts/compress-dist.js",
     "prebuild": "npm run clean && npm run version-sync && npm run changelog:generate",
     "update-deps": "npm i baseline-browser-mapping@latest -D && update-browserslist-db --yes",
-    "build": "node scripts/time-command.js \"NODE_ENV=production rollup -c\"",
+    "build": "node scripts/time-command.js \"NODE_ENV=production node scripts/build-parallel.js\"",
     "dev": "NODE_ENV=development rollup -c -w",
     "release": "node scripts/time-command.js \"npm run build && npm run compress:dist\"",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prebuild": "npm run clean && npm run version-sync && npm run changelog:generate && node scripts/process-vendor-css.js",
     "update-deps": "npm i baseline-browser-mapping@latest -D && update-browserslist-db --yes",
     "build": "node scripts/time-command.js \"NODE_ENV=production node scripts/build-parallel.js\"",
+    "predev": "node scripts/process-vendor-css.js",
     "dev": "NODE_ENV=development rollup -c -w",
     "release": "node scripts/time-command.js \"npm run build && npm run compress:dist\"",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "version-sync": "node scripts/version-sync.js",
     "changelog:generate": "node scripts/changelog-md-to-html.js",
     "compress:dist": "node scripts/compress-dist.js",
-    "prebuild": "npm run clean && npm run version-sync && npm run changelog:generate",
+    "prebuild": "npm run clean && npm run version-sync && npm run changelog:generate && node scripts/process-vendor-css.js",
     "update-deps": "npm i baseline-browser-mapping@latest -D && update-browserslist-db --yes",
     "build": "node scripts/time-command.js \"NODE_ENV=production node scripts/build-parallel.js\"",
     "dev": "NODE_ENV=development rollup -c -w",
@@ -56,6 +56,7 @@
     "babel-plugin-import": "^1.13.8",
     "baseline-browser-mapping": "^2.10.15",
     "cssnano": "^7.1.1",
+    "esbuild-sass-plugin": "^3.7.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
@@ -73,7 +74,7 @@
     "update-browserslist-db": "^1.2.3"
   },
   "dependencies": {
-    "antd": "^6.3.1",
+    "antd": "^6.3.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "prettier": "^3.7.3",
     "rollup": "^4.50.1",
     "rollup-plugin-copy": "^3.5.0",
+    "rollup-plugin-esbuild": "^6.2.1",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-visualizer": "^6.0.3",
     "sass": "^1.92.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -220,6 +220,18 @@ const entryPoints = [
     format: 'iife', // IIFE
     cssFilename: null,
   },
+  // In production, menu.tsx is built by esbuild directly (scripts/build-parallel.js)
+  // for speed. In development/watch mode rollup handles it so `npm run dev` works.
+  ...(!isProduction
+    ? [
+        {
+          input: 'src/popup/menu.tsx',
+          output: 'popup/menu',
+          format: 'iife',
+          cssFilename: 'menu.css',
+        },
+      ]
+    : []),
 ];
 
 // Generate a config for each entry point

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -186,24 +186,8 @@ const oncePlugins = [
       { src: 'src/assets/fonts/*.woff2', dest: 'dist/assets/fonts' },
       { src: 'src/_locales/**', dest: 'dist/_locales' },
       { src: 'src/offscreen/offscreen.html', dest: 'dist/offscreen' },
-      // Copy Ant Design styles
-      {
-        src: 'node_modules/antd/dist/reset.css',
-        dest: 'dist/popup',
-        transform: async (contents, filename) => {
-          if (isProduction) {
-            const postcssResult = await postcss([
-              autoprefixer(),
-              cssnano(),
-            ]).process(contents, {
-              from: filename,
-              to: 'reset.css',
-            });
-            return postcssResult.css;
-          }
-          return contents; // Return the original contents in development mode
-        },
-      },
+      // Copy pre-processed Ant Design reset CSS (processed once by scripts/process-vendor-css.js)
+      { src: '.build-cache/vendor-reset.css', dest: 'dist/popup', rename: 'reset.css' },
     ],
     hook: 'writeBundle',
   }),
@@ -229,12 +213,6 @@ const entryPoints = [
     output: 'scripts/main-content',
     format: 'iife', // IIFE
     cssFilename: 'main-content.css',
-  },
-  {
-    input: 'src/popup/menu.tsx',
-    output: 'popup/menu',
-    format: 'iife', // IIFE
-    cssFilename: 'menu.css',
   },
   {
     input: 'src/offscreen/offscreen.ts',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -174,6 +174,10 @@ const commonPlugins = [
     include: /node_modules/,
     ignoreGlobal: false,
   }),
+].filter(Boolean);
+
+// Plugins that should only run once (not safe to run in parallel across multiple bundles)
+const oncePlugins = [
   copy({
     targets: [
       { src: 'src/manifest.json', dest: 'dist' },
@@ -241,10 +245,12 @@ const entryPoints = [
 ];
 
 // Generate a config for each entry point
-export default entryPoints.map(({ input, output, format, cssFilename }) => {
+export default entryPoints.map(({ input, output, format, cssFilename }, index) => {
   const pluginsForThisEntry = [
     ...commonPlugins,
     cssFilename && postcssPlugin(cssFilename),
+    // copy + visualizer run once, attached to the first entry to avoid parallel race conditions
+    ...(index === 0 ? oncePlugins : []),
   ].filter(Boolean);
 
   const config = {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,8 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import babel from '@rollup/plugin-babel';
+import esbuild from 'rollup-plugin-esbuild';
 import commonjs from '@rollup/plugin-commonjs';
 import copy from 'rollup-plugin-copy';
 import replace from '@rollup/plugin-replace';
-import terser from '@rollup/plugin-terser';
 import json from '@rollup/plugin-json';
 import { visualizer } from 'rollup-plugin-visualizer';
 import postcssRollup from 'rollup-plugin-postcss';
@@ -159,14 +158,11 @@ const commonPlugins = [
       : JSON.stringify(''),
   }),
   json(),
-  babel({
-    babelHelpers: 'bundled',
-    exclude: 'node_modules/**',
-    presets: [
-      ['@babel/preset-react', { runtime: 'automatic' }],
-      '@babel/preset-typescript',
-    ],
-    extensions: ['.js', '.jsx', '.ts', '.tsx'],
+  esbuild({
+    target: 'chrome100',
+    jsx: 'automatic',
+    exclude: /node_modules/,
+    minify: isProduction,
   }),
   nodeResolve({
     browser: true,
@@ -207,7 +203,6 @@ const commonPlugins = [
     ],
     hook: 'writeBundle',
   }),
-  isProduction && terser(),
   isProduction &&
     visualizer({
       filename: 'bundle-report.html',

--- a/scripts/build-parallel.js
+++ b/scripts/build-parallel.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+/**
+ * Builds all rollup entry points in parallel using the JS API.
+ * Equivalent to `rollup -c` but runs all configs concurrently instead of sequentially.
+ */
+
+import { rollup } from 'rollup';
+import { loadConfigFile } from 'rollup/loadConfigFile';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const configPath = path.resolve(__dirname, '../rollup.config.js');
+
+const { options, warnings } = await loadConfigFile(configPath);
+warnings.flush();
+
+await Promise.all(
+  options.map(async inputOptions => {
+    const start = Date.now();
+    const bundle = await rollup(inputOptions);
+    const outputs = Array.isArray(inputOptions.output)
+      ? inputOptions.output
+      : [inputOptions.output];
+    for (const output of outputs) {
+      await bundle.write(output);
+    }
+    await bundle.close();
+    const elapsed = ((Date.now() - start) / 1000).toFixed(2);
+    console.log(`  ${inputOptions.input} → ${outputs[0].file} (${elapsed}s)`);
+  }),
+);

--- a/scripts/build-parallel.js
+++ b/scripts/build-parallel.js
@@ -1,33 +1,68 @@
 #!/usr/bin/env node
 
 /**
- * Builds all rollup entry points in parallel using the JS API.
- * Equivalent to `rollup -c` but runs all configs concurrently instead of sequentially.
+ * Builds all rollup entry points in parallel using the JS API, and builds
+ * src/popup/menu.tsx directly with esbuild (bypassing rollup's commonjs plugin,
+ * which is slow for antd's CJS-only dependencies).
  */
 
 import { rollup } from 'rollup';
 import { loadConfigFile } from 'rollup/loadConfigFile';
+import * as esbuild from 'esbuild';
+import { sassPlugin } from 'esbuild-sass-plugin';
+import { readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const configPath = path.resolve(__dirname, '../rollup.config.js');
+const rootDir = path.resolve(__dirname, '..');
+const configPath = path.resolve(rootDir, 'rollup.config.js');
+
+const pkg = JSON.parse(readFileSync(path.resolve(rootDir, 'package.json'), 'utf8'));
+const isProduction = process.env.NODE_ENV === 'production';
 
 const { options, warnings } = await loadConfigFile(configPath);
 warnings.flush();
 
-await Promise.all(
-  options.map(async inputOptions => {
-    const start = Date.now();
-    const bundle = await rollup(inputOptions);
-    const outputs = Array.isArray(inputOptions.output)
-      ? inputOptions.output
-      : [inputOptions.output];
-    for (const output of outputs) {
-      await bundle.write(output);
-    }
-    await bundle.close();
-    const elapsed = ((Date.now() - start) / 1000).toFixed(2);
-    console.log(`  ${inputOptions.input} → ${outputs[0].file} (${elapsed}s)`);
-  }),
-);
+const buildWithRollup = async inputOptions => {
+  const start = Date.now();
+  const bundle = await rollup(inputOptions);
+  const outputs = Array.isArray(inputOptions.output)
+    ? inputOptions.output
+    : [inputOptions.output];
+  for (const output of outputs) {
+    await bundle.write(output);
+  }
+  await bundle.close();
+  const elapsed = ((Date.now() - start) / 1000).toFixed(2);
+  console.log(`  ${inputOptions.input} → ${outputs[0].file} (${elapsed}s)`);
+};
+
+const buildMenuWithEsbuild = async () => {
+  const start = Date.now();
+  await esbuild.build({
+    // Use outdir so esbuild can place font assets relative to it via assetNames
+    entryPoints: { menu: 'src/popup/menu.tsx' },
+    bundle: true,
+    format: 'iife',
+    globalName: 'popup_menu',
+    outdir: 'dist/popup',
+    // Fonts: output to dist/assets/fonts/ so CSS references (../assets/fonts/*)
+    // match what the copy plugin places there for other entry points.
+    assetNames: '../assets/fonts/[name]',
+    loader: { '.woff2': 'file' },
+    platform: 'browser',
+    target: 'chrome100',
+    minify: isProduction,
+    define: {
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production'),
+      __BP_APP_VERSION__: JSON.stringify(pkg.version || ''),
+    },
+    tsconfig: './tsconfig.json',
+    plugins: [sassPlugin()],
+  });
+  const elapsed = ((Date.now() - start) / 1000).toFixed(2);
+  console.log(`  src/popup/menu.tsx → dist/popup/menu.js (${elapsed}s)`);
+};
+
+await Promise.all([...options.map(buildWithRollup), buildMenuWithEsbuild()]);

--- a/scripts/process-vendor-css.js
+++ b/scripts/process-vendor-css.js
@@ -21,8 +21,10 @@ const cacheDir = resolve(rootDir, '.build-cache');
 const cacheFile = resolve(cacheDir, 'vendor-reset.css');
 const versionFile = resolve(cacheDir, 'vendor-reset.version');
 
-const pkg = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf8'));
-const antdVersion = pkg.dependencies?.antd ?? 'unknown';
+const antdPkg = JSON.parse(
+  readFileSync(resolve(rootDir, 'node_modules/antd/package.json'), 'utf8'),
+);
+const antdVersion = antdPkg.version;
 
 const cacheValid =
   existsSync(cacheFile) &&
@@ -35,7 +37,7 @@ if (cacheValid) {
 }
 
 const resetCssPath = resolve(rootDir, 'node_modules/antd/dist/reset.css');
-const contents = readFileSync(resetCssPath);
+const contents = readFileSync(resetCssPath, 'utf8');
 
 const result = await postcss([autoprefixer(), cssnano()]).process(contents, {
   from: resetCssPath,

--- a/scripts/process-vendor-css.js
+++ b/scripts/process-vendor-css.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+/**
+ * Processes antd/dist/reset.css with PostCSS (autoprefixer + cssnano) and caches the
+ * result in .build-cache/ keyed by antd version. On a cache hit the script exits
+ * immediately so subsequent builds pay only a file-read cost.
+ *
+ * Output: .build-cache/vendor-reset.css  (copied to dist/popup/reset.css by the copy plugin)
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import postcss from 'postcss';
+import autoprefixer from 'autoprefixer';
+import cssnano from 'cssnano';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(__dirname, '..');
+const cacheDir = resolve(rootDir, '.build-cache');
+const cacheFile = resolve(cacheDir, 'vendor-reset.css');
+const versionFile = resolve(cacheDir, 'vendor-reset.version');
+
+const pkg = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf8'));
+const antdVersion = pkg.dependencies?.antd ?? 'unknown';
+
+const cacheValid =
+  existsSync(cacheFile) &&
+  existsSync(versionFile) &&
+  readFileSync(versionFile, 'utf8').trim() === antdVersion;
+
+if (cacheValid) {
+  console.log(`  vendor-reset.css: cache hit (antd ${antdVersion})`);
+  process.exit(0);
+}
+
+const resetCssPath = resolve(rootDir, 'node_modules/antd/dist/reset.css');
+const contents = readFileSync(resetCssPath);
+
+const result = await postcss([autoprefixer(), cssnano()]).process(contents, {
+  from: resetCssPath,
+  to: 'reset.css',
+});
+
+mkdirSync(cacheDir, { recursive: true });
+writeFileSync(cacheFile, result.css);
+writeFileSync(versionFile, antdVersion);
+console.log(`  vendor-reset.css: processed and cached (antd ${antdVersion})`);


### PR DESCRIPTION
# Overview:

This PR rewrites the extension build pipeline to avoid repeating expensive work across builds (notably around Ant Design and bundling), targeting a large build-time reduction. Dropping total build time from ~9s to ~1.1s.

**Key Changes:**
- Add a cached PostCSS preprocessing step for `antd/dist/reset.css` into `.build-cache/` and copy the cached result into `dist/`.
- Build Rollup entry points in parallel via a new Node script, and build the popup menu entry (`src/popup/menu.tsx`) with esbuild instead of Rollup.
- Replace Babel/Terser in Rollup with `rollup-plugin-esbuild`, and update dependencies (including `antd`).

Example build:
```
npm run build

> border-patrol@1.7.1 prebuild
> npm run clean && npm run version-sync && npm run changelog:generate && node scripts/process-vendor-css.js

> border-patrol@1.7.1 clean
> rm -rf dist

> border-patrol@1.7.1 version-sync
> node scripts/version-sync.js

Current version from package.json: 1.7.1
Version sync complete!

> border-patrol@1.7.1 changelog:generate
> node scripts/changelog-md-to-html.js

Changelog has been converted to landing/changelog.html
  vendor-reset.css: cache hit (antd ^6.3.5)

> border-patrol@1.7.1 build
> node scripts/time-command.js "NODE_ENV=production node scripts/build-parallel.js"

Building for production...
  src/offscreen/offscreen.ts → dist/offscreen/offscreen.js (0.22s)
  src/popup/menu.tsx → dist/popup/menu.js (0.50s)
  src/scripts/main-content.ts → dist/scripts/main-content.js (0.51s)
  src/background.ts → dist/background.js (0.53s)

✨ Build completed in 1.09s
```
