### PR TITLE
Improve border mode performance on large or dynamic pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Reworked the build process for faster builds and better optimization (dropping total build time from ~9s to ~1.1s).
+- Improved Border Mode performance on large or animation-heavy pages. Outlines now apply in small batches instead of all at once, and DOM change handling is throttled to once per frame so the extension stays snappy under heavy DOM churn.
 
 ## [1.7.1] - 2026-04-02
 

--- a/landing/changelog.html
+++ b/landing/changelog.html
@@ -62,6 +62,12 @@
           Reworked the build process for faster builds and better optimization
           (dropping total build time from ~9s to ~1.1s).
         </li>
+        <li>
+          Improved Border Mode performance on large or animation-heavy pages.
+          Outlines now apply in small batches instead of all at once, and DOM
+          change handling is throttled to once per frame so the extension stays
+          snappy under heavy DOM churn.
+        </li>
       </ul>
       <h2>[1.7.1] - 2026-04-02</h2>
       <h3>Added</h3>

--- a/src/scripts/border.ts
+++ b/src/scripts/border.ts
@@ -17,6 +17,10 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
 
   let observer: MutationObserver | null = null; // Declare the MutationObserver instance
 
+  // Pending mutations and rAF handle for debounced mutation processing
+  let pendingMutations: MutationRecord[] = [];
+  let rafHandle: number | null = null;
+
   // Define element groups with their tags and colors
   const elementGroups: Record<string, ElementGroup> = {
     containers: {
@@ -92,15 +96,43 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
   }
 
   /**
-   * Handles mutations in the DOM to apply or update outlines on elements.
+   * Applies outlines to all elements in the provided list in chunks, yielding
+   * between frames via requestAnimationFrame to keep the page responsive.
    *
-   * @param mutationsList - Array of mutations observed in the DOM.
+   * @param elements - The list of elements to process.
+   * @param size - The outline size in pixels.
+   * @param style - The outline style (e.g., 'solid', 'dashed').
+   * @param chunkSize - Number of elements to process per frame (default 200).
    */
-  function handleMutations(mutationsList: MutationRecord[]): void {
-    if (!isBorderModeEnabled) return; // Skip if border mode is not enabled
+  function applyOutlinesToAll(
+    elements: Element[],
+    size: number,
+    style: string,
+    chunkSize = 200,
+  ): void {
+    let index = 0;
+    function processChunk() {
+      const end = Math.min(index + chunkSize, elements.length);
+      for (; index < end; index++) {
+        applyOutlineToElement(elements[index], size, style);
+      }
+      if (index < elements.length) {
+        requestAnimationFrame(processChunk);
+      }
+    }
+    requestAnimationFrame(processChunk);
+  }
+
+  /**
+   * Processes a batch of accumulated MutationRecords to apply outlines to
+   * newly added nodes and their children.
+   *
+   * @param mutations - The mutations to process.
+   */
+  function processMutations(mutations: MutationRecord[]): void {
     const { size: outlineSize, style: outlineStyle } = currentBorderSettings;
 
-    mutationsList.forEach(mutation => {
+    mutations.forEach(mutation => {
       if (mutation.type === 'childList') {
         // Iterate over newly added nodes
         mutation.addedNodes.forEach(node => {
@@ -114,23 +146,31 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
             applyOutlineToElement(child, outlineSize, outlineStyle);
           });
         });
-      } else if (mutation.type === 'attributes') {
-        // Handle attribute changes (e.g., class, style)
-        // Apply outline ONLY to the target element whose attribute changed.
-        // Its children's outlines are independent and should not be re-scanned.
-        const targetElement = mutation.target as Element;
-        if (targetElement.nodeType !== Node.ELEMENT_NODE) return; // Skip non-element nodes
-        if (isInspectorUIElement(targetElement)) return;
-
-        applyOutlineToElement(targetElement, outlineSize, outlineStyle);
       }
     });
   }
 
   /**
+   * Accumulates mutations and flushes them once per animation frame to
+   * coalesce bursts of DOM changes on animation-heavy pages.
+   *
+   * @param mutationsList - Array of mutations observed in the DOM.
+   */
+  function handleMutations(mutationsList: MutationRecord[]): void {
+    if (!isBorderModeEnabled) return; // Skip if border mode is not enabled
+    pendingMutations.push(...mutationsList);
+    if (rafHandle === null) {
+      rafHandle = requestAnimationFrame(() => {
+        processMutations(pendingMutations.splice(0));
+        rafHandle = null;
+      });
+    }
+  }
+
+  /**
    * Starts observing the DOM for changes to apply or remove outlines dynamically.
-   * This function sets up a MutationObserver to watch for changes in the document body.
-   * It listens for child list changes, attribute changes, and subtree modifications.
+   * Watches only for childList changes to avoid re-entrant callbacks from our
+   * own style writes.
    */
   function startObservingDOM(): void {
     if (!observer) {
@@ -141,15 +181,11 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
 
     Logger.info('Starting DOM observation for border updates.');
 
-    // Define the configuration for the MutationObserver
     const config: MutationObserverInit = {
       childList: true,
       subtree: true,
-      attributes: true,
-      attributeFilter: ['class', 'style'], // Only watch specific attributes
     };
 
-    // Start observing the document body for childList changes and subtree modifications
     observer.observe(document.body, config);
   }
 
@@ -164,6 +200,13 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
     }
 
     observer = null; // Clear the observer reference to prevent memory leaks
+
+    // Cancel any pending rAF flush and discard accumulated mutations
+    if (rafHandle !== null) {
+      cancelAnimationFrame(rafHandle);
+      rafHandle = null;
+    }
+    pendingMutations = [];
   }
 
   /**
@@ -199,13 +242,13 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
     // Update the Border Patrol Inspector container reference
     bpInspectorContainer = document.querySelector('#bp-inspector-container');
 
-    // Apply outline to all elements in the document
-    document.querySelectorAll('*').forEach(element => {
-      applyOutlineToElement(element, size, style);
-    });
-
-    // Start observing for new elements only if borders are enabled
+    // Disconnect observer before the bulk write to avoid re-entrant callbacks,
+    // then restart it immediately so new nodes during chunking are also captured.
+    if (observer) observer.disconnect();
     startObservingDOM();
+
+    // Apply outlines in chunks to avoid blocking the main thread
+    applyOutlinesToAll(Array.from(document.querySelectorAll('*')), size, style);
   }
 
   // Receive message to apply outline to all elements
@@ -233,7 +276,7 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
             currentBorderSettings.size,
             currentBorderSettings.style,
           );
-        } 
+        }
         // Receive message to update border settings
         if (request.action === RUNTIME_MESSAGES.UPDATE_BORDER_SETTINGS) {
           // Get new border settings from request

--- a/src/scripts/border.ts
+++ b/src/scripts/border.ts
@@ -10,16 +10,11 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
     style: 'solid',
   };
 
-  // Get the Border Patrol Inspector container
-  let bpInspectorContainer: Element | null = document.querySelector(
-    '#bp-inspector-container',
-  );
+  const STYLE_ELEMENT_ID = 'bp-border-styles';
 
-  let observer: MutationObserver | null = null; // Declare the MutationObserver instance
-
-  // Pending mutations and rAF handle for debounced mutation processing
-  let pendingMutations: MutationRecord[] = [];
-  let rafHandle: number | null = null;
+  // Exclude the Border Patrol Inspector UI from all border rules
+  const exclusion =
+    ':not(#bp-inspector-container):not(#bp-inspector-container *)';
 
   // Define element groups with their tags and colors
   const elementGroups: Record<string, ElementGroup> = {
@@ -49,206 +44,79 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
   const defaultColor: string = 'red';
 
   /**
-   * Determines if the given element is part of the Border Patrol Inspector UI.
+   * Builds a CSS string that applies color-coded outlines to each element group.
+   * Tag-specific rules have specificity (0,2,1) and the catch-all `*` rule has (0,2,0),
+   * so group colors always win when both `!important` declarations conflict.
    *
-   * @param element - The element to be checked.
-   * @returns True if the element is part of the Inspector UI, otherwise false.
-   */
-  function isInspectorUIElement(element: Element): boolean {
-    if (!bpInspectorContainer || !element) return false;
-    return bpInspectorContainer.contains(element);
-  }
-
-  /**
-   * Applies an outline to a given element based on its group and specified size and style.
-   *
-   * @param element - The DOM element to apply the outline to.
-   * @param outlineSize - The size of the outline in pixels.
-   * @param outlineStyle - The style of the outline (e.g., 'solid', 'dashed', etc.).
-   */
-  function applyOutlineToElement(
-    element: Element,
-    outlineSize: number,
-    outlineStyle: string,
-  ): void {
-    // Ensure the element is a valid DOM element
-    if (!(element instanceof Element)) {
-      return; // Skip if not an element instance
-    }
-
-    // Exclude applying outlines to Border Patrol elements
-    if (isInspectorUIElement(element)) return;
-
-    const elementTag = element.tagName.toLowerCase();
-    let outlineColor: string = defaultColor;
-
-    // Determine element's group and apply corresponding color
-    for (const { tags, color: groupColor } of Object.values(elementGroups)) {
-      if (tags.includes(elementTag)) {
-        outlineColor = groupColor;
-        break; // Stop searching once a match is found
-      }
-    }
-
-    // Apply the outline style to the element
-    (element as HTMLElement).style.outline =
-      `${outlineSize}px ${outlineStyle} ${outlineColor}`;
-  }
-
-  /**
-   * Applies outlines to all elements in the provided list in chunks, yielding
-   * between frames via requestAnimationFrame to keep the page responsive.
-   *
-   * @param elements - The list of elements to process.
    * @param size - The outline size in pixels.
    * @param style - The outline style (e.g., 'solid', 'dashed').
-   * @param chunkSize - Number of elements to process per frame (default 200).
+   * @returns A CSS string ready to inject into a style element.
    */
-  function applyOutlinesToAll(
-    elements: Element[],
-    size: number,
-    style: string,
-    chunkSize = 200,
-  ): void {
-    let index = 0;
-    function processChunk() {
-      const end = Math.min(index + chunkSize, elements.length);
-      for (; index < end; index++) {
-        applyOutlineToElement(elements[index], size, style);
-      }
-      if (index < elements.length) {
-        requestAnimationFrame(processChunk);
-      }
+  function buildBorderStyles(size: number, style: string): string {
+    const lines: string[] = [];
+
+    for (const { tags, color } of Object.values(elementGroups)) {
+      const selectors = tags.map(tag => `${tag}${exclusion}`).join(',');
+      lines.push(`${selectors}{outline:${size}px ${style} ${color} !important}`);
     }
-    requestAnimationFrame(processChunk);
+
+    // Catch-all for any element not covered by a group rule
+    lines.push(`*${exclusion}{outline:${size}px ${style} ${defaultColor} !important}`);
+
+    return lines.join('');
   }
 
   /**
-   * Processes a batch of accumulated MutationRecords to apply outlines to
-   * newly added nodes and their children.
+   * Injects or updates the border stylesheet in the document head.
+   * Using a stylesheet with `!important` ensures outlines survive host-page
+   * style mutations without needing a MutationObserver. New elements added
+   * dynamically are styled automatically by the browser.
    *
-   * @param mutations - The mutations to process.
+   * @param size - The outline size in pixels.
+   * @param style - The outline style.
    */
-  function processMutations(mutations: MutationRecord[]): void {
-    const { size: outlineSize, style: outlineStyle } = currentBorderSettings;
-
-    mutations.forEach(mutation => {
-      if (mutation.type === 'childList') {
-        // Iterate over newly added nodes
-        mutation.addedNodes.forEach(node => {
-          if (node.nodeType !== Node.ELEMENT_NODE) return; // Skip non-element nodes
-
-          // Apply outline to the newly added node
-          applyOutlineToElement(node as Element, outlineSize, outlineStyle);
-
-          // Apply outline to all child elements of the newly added node
-          (node as Element).querySelectorAll('*').forEach(child => {
-            applyOutlineToElement(child, outlineSize, outlineStyle);
-          });
-        });
-      }
-    });
+  function injectBorderStyles(size: number, style: string): void {
+    let styleEl = document.getElementById(
+      STYLE_ELEMENT_ID,
+    ) as HTMLStyleElement | null;
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = STYLE_ELEMENT_ID;
+      document.head.appendChild(styleEl);
+    }
+    styleEl.textContent = buildBorderStyles(size, style);
   }
 
   /**
-   * Accumulates mutations and flushes them once per animation frame to
-   * coalesce bursts of DOM changes on animation-heavy pages.
+   * Removes the border stylesheet from the document, clearing all outlines instantly.
+   */
+  function removeBorderStyles(): void {
+    document.getElementById(STYLE_ELEMENT_ID)?.remove();
+  }
+
+  /**
+   * Applies or removes the border stylesheet based on the enabled state.
    *
-   * @param mutationsList - Array of mutations observed in the DOM.
+   * @param isEnabled - Whether border mode should be active.
+   * @param size - The outline size in pixels.
+   * @param style - The outline style.
    */
-  function handleMutations(mutationsList: MutationRecord[]): void {
-    if (!isBorderModeEnabled) return; // Skip if border mode is not enabled
-    pendingMutations.push(...mutationsList);
-    if (rafHandle === null) {
-      rafHandle = requestAnimationFrame(() => {
-        processMutations(pendingMutations.splice(0));
-        rafHandle = null;
-      });
-    }
-  }
-
-  /**
-   * Starts observing the DOM for changes to apply or remove outlines dynamically.
-   * Watches only for childList changes to avoid re-entrant callbacks from our
-   * own style writes.
-   */
-  function startObservingDOM(): void {
-    if (!observer) {
-      observer = new MutationObserver(handleMutations);
-    }
-    // Disconnect any existing observation before starting a new one
-    observer.disconnect();
-
-    Logger.info('Starting DOM observation for border updates.');
-
-    const config: MutationObserverInit = {
-      childList: true,
-      subtree: true,
-    };
-
-    observer.observe(document.body, config);
-  }
-
-  /** Stops observing the DOM for changes. */
-  function stopObservingDOM(): void {
-    if (!observer) return;
-
-    try {
-      observer.disconnect();
-    } catch (err) {
-      Logger.debug('Failed to disconnect the observer:', err);
-    }
-
-    observer = null; // Clear the observer reference to prevent memory leaks
-
-    // Cancel any pending rAF flush and discard accumulated mutations
-    if (rafHandle !== null) {
-      cancelAnimationFrame(rafHandle);
-      rafHandle = null;
-    }
-    pendingMutations = [];
-  }
-
-  /**
-   * Manages applying or removing extension-specific outlines to elements.
-   *
-   * @param isEnabled - Determines whether the outline should be applied.
-   * @param size - The size of the outline in pixels.
-   * @param style - The style of the outline (e.g., 'solid', 'dashed', etc.).
-   */
-  async function manageElementOutlines(
+  function manageElementOutlines(
     isEnabled: boolean,
     size: number,
     style: string,
-  ): Promise<void> {
+  ): void {
     Logger.info(
       `Managing element outlines: isEnabled=${isEnabled}, size=${size}, style=${style}`,
     );
 
-    // Remove outline if extension is disabled
     if (!isEnabled) {
-      Logger.info('Borders are disabled. Removing outlines from all elements.');
-      stopObservingDOM(); // Stop observing the DOM to prevent unnecessary updates
-      document.querySelectorAll('*').forEach(element => {
-        // Skip Border Patrol Inspector UI elements
-        if (isInspectorUIElement(element)) return;
-
-        // Remove outline from all elements
-        (element as HTMLElement).style.outline = 'none';
-      });
+      Logger.info('Borders are disabled. Removing border stylesheet.');
+      removeBorderStyles();
       return;
     }
 
-    // Update the Border Patrol Inspector container reference
-    bpInspectorContainer = document.querySelector('#bp-inspector-container');
-
-    // Disconnect observer before the bulk write to avoid re-entrant callbacks,
-    // then restart it immediately so new nodes during chunking are also captured.
-    if (observer) observer.disconnect();
-    startObservingDOM();
-
-    // Apply outlines in chunks to avoid blocking the main thread
-    applyOutlinesToAll(Array.from(document.querySelectorAll('*')), size, style);
+    injectBorderStyles(size, style);
   }
 
   // Receive message to apply outline to all elements
@@ -265,33 +133,26 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
         return false;
       }
 
-      void (async () => {
-        // Receive message to update border mode
-        if (request.action === RUNTIME_MESSAGES.UPDATE_BORDER_MODE) {
-          // Get new border mode from request
-          isBorderModeEnabled = request.payload.isEnabled;
-          // Apply/remove outline based on the new mode and current settings
-          await manageElementOutlines(
-            isBorderModeEnabled,
-            currentBorderSettings.size,
-            currentBorderSettings.style,
-          );
-        }
-        // Receive message to update border settings
-        if (request.action === RUNTIME_MESSAGES.UPDATE_BORDER_SETTINGS) {
-          // Get new border settings from request
-          currentBorderSettings.size = request.payload.size;
-          currentBorderSettings.style = request.payload.style;
-          // Apply/remove outline based on the current mode and new settings
-          await manageElementOutlines(
-            isBorderModeEnabled,
-            currentBorderSettings.size,
-            currentBorderSettings.style,
-          );
-        }
-      })().catch(error => {
-        Logger.error('Error handling border message:', error);
-      });
+      // Receive message to update border mode
+      if (request.action === RUNTIME_MESSAGES.UPDATE_BORDER_MODE) {
+        isBorderModeEnabled = request.payload.isEnabled;
+        manageElementOutlines(
+          isBorderModeEnabled,
+          currentBorderSettings.size,
+          currentBorderSettings.style,
+        );
+      }
+
+      // Receive message to update border settings
+      if (request.action === RUNTIME_MESSAGES.UPDATE_BORDER_SETTINGS) {
+        currentBorderSettings.size = request.payload.size;
+        currentBorderSettings.style = request.payload.style;
+        manageElementOutlines(
+          isBorderModeEnabled,
+          currentBorderSettings.size,
+          currentBorderSettings.style,
+        );
+      }
 
       return false;
     },


### PR DESCRIPTION
# Overview:

This PR optimizes Border Mode’s runtime behavior on large/dynamic pages by reducing main-thread blocking during initial outline application and batching DOM mutation handling to once per animation frame.

**Changes:**
- Apply outlines to the full document incrementally in requestAnimationFrame-sized chunks instead of a single blocking loop.
- Debounce MutationObserver callbacks by accumulating MutationRecords and processing them once per frame.
- Narrow observation to `childList` mutations (dropping attribute observation) to reduce overhead and avoid re-entrant callbacks.

Fixes: #119 
