### PR TITLE
Add privacy policies to landing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to Border Patrol! This project is a free and open-source Chrome extension, and contributions from the community are incredibly valuable and help make it a better tool for everyone.
 
-By contributing, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md) and that your contributions will be licensed under the project's [Apache-2.0 License](https://github.com/craigsavage/border-patrol/blob/main/LICENSE).
+By contributing, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md) and that your contributions will be licensed under the project's [Apache-2.0 License](https://github.com/seasav/border-patrol/blob/main/LICENSE).
 
 Please take a moment to review these guidelines before submitting bug reports, feature requests, or pull requests.
 
@@ -12,7 +12,7 @@ There are several ways you can contribute to the Border Patrol project:
 
 ### 🐛 Reporting Bugs
 
-If you encounter a bug or unexpected behavior, please help us by submitting a clear and concise issue in the [GitHub repository Issues page](https://github.com/craigsavage/border-patrol/issues).
+If you encounter a bug or unexpected behavior, please help us by submitting a clear and concise issue in the [GitHub repository Issues page](https://github.com/seasav/border-patrol/issues).
 
 When reporting a bug, please include as much detail as possible, such as:
 
@@ -29,7 +29,7 @@ When reporting a bug, please include as much detail as possible, such as:
 
 Have an idea for a new feature, an improvement to existing functionality, or a better way to do something? We'd love to hear your suggestions!
 
-Please submit your enhancement suggestion as an issue in the [GitHub repository Issues page](https://github.com/craigsavage/border-patrol/issues).
+Please submit your enhancement suggestion as an issue in the [GitHub repository Issues page](https://github.com/seasav/border-patrol/issues).
 
 When suggesting an enhancement, please include:
 
@@ -42,7 +42,7 @@ When suggesting an enhancement, please include:
 
 Code contributions are very welcome! If you'd like to contribute code, please follow these steps:
 
-1. **Fork the Repository:** Fork the [Border Patrol repository](https://github.com/craigsavage/border-patrol) to your personal GitHub account.
+1. **Fork the Repository:** Fork the [Border Patrol repository](https://github.com/seasav/border-patrol) to your personal GitHub account.
 2. **Clone Your Fork:** Clone your forked repository to your local machine.
 
    ```bash
@@ -55,7 +55,7 @@ Code contributions are very welcome! If you'd like to contribute code, please fo
 3. **Set Up Upstream:** Add the original repository as an upstream remote to keep your fork updated.
 
    ```bash
-   git remote add upstream https://github.com/craigsavage/border-patrol.git
+   git remote add upstream https://github.com/seasav/border-patrol.git
    ```
 
 4. **Sync with Upstream:** Before starting work, sync your local `dev` branch with the latest changes from the main repository's `dev` branch.
@@ -94,7 +94,7 @@ Code contributions are very welcome! If you'd like to contribute code, please fo
     git push origin your-contribution-branch-name
     ```
 
-11. **Open a Pull Request (PR):** Go to the original [Border Patrol repository](https://github.com/craigsavage/border-patrol) on GitHub. You should see a prompt to compare & create a pull request from your new branch.
+11. **Open a Pull Request (PR):** Go to the original [Border Patrol repository](https://github.com/seasav/border-patrol) on GitHub. You should see a prompt to compare & create a pull request from your new branch.
 
 - **Ensure the pull request is targeting the `dev` branch** of the main repository.
 - Provide a clear title and description for your pull request, explaining the changes you've made. Reference any related issues by number (e.g., `Closes #42`, `Fixes #123`).
@@ -111,7 +111,7 @@ This project is committed to providing a welcoming and inclusive environment for
 
 ## 📄 Licensing
 
-By contributing to Border Patrol, you agree that your contributions will be licensed under the project's [Apache-2.0 License](https://github.com/craigsavage/border-patrol/blob/main/LICENSE).
+By contributing to Border Patrol, you agree that your contributions will be licensed under the project's [Apache-2.0 License](https://github.com/seasav/border-patrol/blob/main/LICENSE).
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 END OF TERMS AND CONDITIONS
 
-Copyright © 2025 craigsavage
+Copyright © 2026 SeaSav Labs Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Please see the [CONTRIBUTING](CONTRIBUTING.md) file for more detailed guidelines
 
 ### Feedback and Support 💬
 
-For bug reports, feature requests, or general feedback, please open an issue on the [Border Patrol GitHub Issues page](https://github.com/craigsavage/border-patrol/issues).
+For bug reports, feature requests, or general feedback, please open an issue on the [Border Patrol GitHub Issues page](https://github.com/seasav/border-patrol/issues).
 
 ### License
 
-Border Patrol is released under the [Apache-2.0 License](https://github.com/craigsavage/border-patrol/blob/main/LICENSE) 📄.
+Border Patrol is released under the [Apache-2.0 License](https://github.com/seasav/border-patrol/blob/main/LICENSE) 📄.

--- a/docs/permission-usage.md
+++ b/docs/permission-usage.md
@@ -1,0 +1,43 @@
+# Privacy Permissions Usage
+
+These are the permissions that Border Patrol uses and why they are needed. This is used on the chrome web store privacy policy and permissions sections, and should be kept up to date with the actual permissions declared in `manifest.json` and used in the codebase.
+
+## Single purpose description
+
+Visually inspect webpage layouts by outlining HTML elements and showing box model details.
+
+## Permission justification
+
+Border Patrol requires the following permissions to function properly.
+
+Scripting:
+
+> The scripting permission is used in conjunction with activeTab and host_permissions to inject content scripts and CSS into web pages. This is necessary to render the visual outlines and the inspector overlay directly onto the page content as intended by the extension's features.
+
+Storage:
+
+> The storage permission is used to save and retrieve user settings, per-tab state, and feature configurations. This alThe storage permission is used to save and load the extension's settings (like border size and style) and the per-tab state (whether border or inspector mode is enabled for a specific tab) locally within the user's browser. This data is stored only on the user's machine and is not transmitted or shared externally.
+
+ActiveTab:
+
+> The activeTab permission is used to allow the extension to interact with the user's currently active tab only when the user explicitly invokes the extension (e.g., by clicking the extension's icon or using its keyboard shortcut). This is necessary to inject content scripts and CSS, update the action icon, and send messages related to the active tab.
+
+Downloads:
+
+> The downloads permission is exclusively required to enable Border Patrol's "Screenshot Capture" feature, allowing users to save an image of the current webpage (with the extension's outlines applied) directly to their local machine. This action is always initiated explicitly by the user clicking the "Take Screenshot" button, and Border Patrol does not access, collect, transmit, or store any user data or Browse history in relation to this permission or for any other purpose.
+
+ContextMenus:
+
+> ContextMenu is used for quick access to toggling any of the modes by right clicking to open the context menu the selecting the mode. This is added to provide users with even faster access to Border Patrol's core functionality.
+
+Offscreen:
+
+> The "offscreen" permission is required solely to enable the extension’s full page screenshot functionality. No other features use this permission.
+
+Host Permission:
+
+> The host_permissions with <all_urls> is essential for Border Patrol's core functionality. It is required to inject content scripts and CSS into any web page the user visits.
+> Injection occurs automatically when a page finishes loading or when the user switches tabs, as well as via user-initiated actions (icon click, command).
+> While the activeTab permission covers user-initiated injections, it does not grant permission for injections triggered solely by navigation or tab switching events when the user has not just interacted with the extension icon.
+> Therefore, <all_urls> is necessary to ensure Border Patrol reliably injects its scripts and provides visual feedback on page structure and the box model as the user browses normally across all websites.
+> No user data from pages is collected or transmitted externally; access is solely for injecting visual debugging tools onto page content.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -38,20 +38,45 @@ export default function ChangelogPage() {
     <>
       <Nav />
 
-      <div style={{ borderBottom: '1px solid var(--border-color)', background: 'var(--card-background)' }}>
-        <div className="container" style={{ paddingTop: '3rem', paddingBottom: '3rem' }}>
-          <p style={{ fontSize: '0.85rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '1px', color: 'var(--bp-blue-500)', marginBottom: '0.75rem' }}>
+      <div
+        style={{
+          borderBottom: '1px solid var(--border-color)',
+          background: 'var(--card-background)',
+        }}
+      >
+        <div
+          className='container'
+          style={{ paddingTop: '3rem', paddingBottom: '3rem' }}
+        >
+          <p
+            style={{
+              fontSize: '0.85rem',
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: '1px',
+              color: 'var(--bp-blue-500)',
+              marginBottom: '0.75rem',
+            }}
+          >
             Release History
           </p>
-          <h1 style={{ fontSize: '2.5rem', marginBottom: '0.5rem' }}>Changelog</h1>
+          <h1 style={{ fontSize: '2.5rem', marginBottom: '0.5rem' }}>
+            Changelog
+          </h1>
           <p style={{ color: 'var(--light-text-color)', marginBottom: 0 }}>
             All notable changes to Border Patrol, most recent first.
           </p>
         </div>
       </div>
 
-      <main className="container" style={{ paddingTop: '2.5rem', paddingBottom: '5rem' }}>
-        <div className="changelog-content" dangerouslySetInnerHTML={{ __html: changelogHtml }} />
+      <main
+        className='container'
+        style={{ paddingTop: '2.5rem', paddingBottom: '5rem' }}
+      >
+        <div
+          className='changelog-content'
+          dangerouslySetInnerHTML={{ __html: changelogHtml }}
+        />
       </main>
 
       <Footer />

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -37,9 +37,23 @@ export default function ChangelogPage() {
   return (
     <>
       <Nav />
-      <main className="container" style={{ paddingTop: '2rem' }}>
-        <div dangerouslySetInnerHTML={{ __html: changelogHtml }} />
+
+      <div style={{ borderBottom: '1px solid var(--border-color)', background: 'var(--card-background)' }}>
+        <div className="container" style={{ paddingTop: '3rem', paddingBottom: '3rem' }}>
+          <p style={{ fontSize: '0.85rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '1px', color: 'var(--bp-blue-500)', marginBottom: '0.75rem' }}>
+            Release History
+          </p>
+          <h1 style={{ fontSize: '2.5rem', marginBottom: '0.5rem' }}>Changelog</h1>
+          <p style={{ color: 'var(--light-text-color)', marginBottom: 0 }}>
+            All notable changes to Border Patrol, most recent first.
+          </p>
+        </div>
+      </div>
+
+      <main className="container" style={{ paddingTop: '2.5rem', paddingBottom: '5rem' }}>
+        <div className="changelog-content" dangerouslySetInnerHTML={{ __html: changelogHtml }} />
       </main>
+
       <Footer />
     </>
   );

--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -691,22 +691,102 @@ header {
 /* Footer */
 footer {
   background-color: var(--background-dark);
-  color: #fff;
-  text-align: center;
-  padding: 30px 0;
-  font-size: 0.9em;
+  color: var(--bp-blue-300);
 }
 
-footer a {
-  color: var(--bp-blue-300);
+.footer-top {
+  padding: 3rem 0 2.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.footer-layout {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.footer-brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.footer-brand-link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
   text-decoration: none;
 }
 
-footer a:hover {
-  text-decoration: underline;
+.footer-brand-link:hover {
+  text-decoration: none;
 }
 
-/* Changelog Styles */
+.footer-brand-name {
+  font-family: 'Grandstander', 'Inter', sans-serif;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.footer-tagline {
+  font-size: 0.9rem;
+  color: var(--bp-blue-400);
+  margin: 0;
+  font-style: italic;
+}
+
+.footer-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: right;
+}
+
+.footer-links a {
+  color: var(--bp-blue-300);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.2s ease;
+}
+
+.footer-links a:hover {
+  color: #fff;
+  text-decoration: none;
+}
+
+.footer-company-link {
+  color: var(--bp-blue-400) !important;
+  font-weight: 500;
+  margin-top: 0.5rem;
+}
+
+.footer-bottom {
+  padding: 1.25rem 0;
+}
+
+.footer-bottom p {
+  font-size: 0.85rem;
+  color: var(--bp-blue-600);
+  margin: 0;
+  text-align: center;
+}
+
+/* Content page styles (changelog, privacy, terms) */
+main h2 {
+  text-align: left;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  color: var(--bp-blue-800);
+}
+
+main h3 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+  color: var(--bp-blue-700);
+}
+
 main ul {
   list-style-type: disc;
   margin-left: 2rem;
@@ -718,16 +798,44 @@ main ul li {
   line-height: 1.6;
 }
 
-main h2 {
-  margin-top: 2rem;
-  margin-bottom: 1rem;
-  color: var(--bp-blue-800);
+/* Changelog-specific content styles */
+.changelog-content > h1 {
+  display: none; /* title is in the page header banner */
 }
 
-main h3 {
-  margin-top: 1.5rem;
-  margin-bottom: 0.75rem;
-  color: var(--bp-blue-700);
+.changelog-content h2 {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--bp-blue-900);
+  background: var(--bp-blue-50);
+  border: 1px solid var(--bp-blue-200);
+  border-radius: 6px;
+  padding: 0.5rem 0.9rem;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+  display: inline-block;
+}
+
+.changelog-content h3 {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--bp-blue-500);
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.changelog-content ul {
+  list-style-type: disc;
+  margin-left: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.changelog-content ul li {
+  margin-bottom: 0.4rem;
+  line-height: 1.65;
+  color: var(--medium-text-color);
 }
 
 /* Responsive Design */

--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -127,7 +127,9 @@ body {
   border-radius: 12px;
   padding: 2rem;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
 }
 
 .problem-card:hover,
@@ -425,7 +427,9 @@ ul {
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
   background: #fff;
   border: 1px solid rgba(0, 0, 0, 0.1);
 }
@@ -546,7 +550,9 @@ header {
   border-radius: 8px;
   text-decoration: none;
   font-weight: 600;
-  transition: background-color 0.3s ease, color 0.3s ease,
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease,
     border-color 0.3s ease;
   font-size: 1em;
   border: none;
@@ -725,7 +731,7 @@ footer {
 
 .footer-brand-name {
   font-family: 'Grandstander', 'Inter', sans-serif;
-  font-size: 1.2rem;
+  font-size: 1.5rem;
   font-weight: 700;
   color: #fff;
 }
@@ -756,11 +762,6 @@ footer {
   text-decoration: none;
 }
 
-.footer-company-link {
-  color: var(--bp-blue-400) !important;
-  font-weight: 500;
-  margin-top: 0.5rem;
-}
 
 .footer-bottom {
   padding: 1.25rem 0;
@@ -771,6 +772,15 @@ footer {
   color: var(--bp-blue-600);
   margin: 0;
   text-align: center;
+}
+
+.footer-bottom a {
+  color: var(--bp-blue-500);
+  text-decoration: none;
+}
+
+.footer-bottom a:hover {
+  color: var(--bp-blue-300);
 }
 
 /* Content page styles (changelog, privacy, terms) */
@@ -799,8 +809,9 @@ main ul li {
 }
 
 /* Changelog-specific content styles */
-.changelog-content > h1 {
-  display: none; /* title is in the page header banner */
+.changelog-content > h1,
+.changelog-content > p {
+  display: none; /* title and intro line are in the page header banner */
 }
 
 .changelog-content h2 {

--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -22,16 +22,20 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
-    <html lang="en">
+    <html lang='en'>
       <head>
         <link
-          rel="stylesheet"
-          href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-          integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A=="
-          crossOrigin="anonymous"
-          referrerPolicy="no-referrer"
+          rel='stylesheet'
+          href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css'
+          integrity='sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A=='
+          crossOrigin='anonymous'
+          referrerPolicy='no-referrer'
         />
       </head>
       <body>

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -26,51 +26,51 @@ export default function HomePage() {
       <Nav />
 
       <header>
-        <div className="container">
-          <div className="hero">
-            <div className="hero-text">
-              <h1 className="headline">
-                <span className="hero-line-1">Stop Guessing!</span>
-                <span className="hero-line-2">
+        <div className='container'>
+          <div className='hero'>
+            <div className='hero-text'>
+              <h1 className='headline'>
+                <span className='hero-line-1'>Stop Guessing!</span>
+                <span className='hero-line-2'>
                   <span>Start</span>
-                  <span className="hero-highlight">Seeing</span>
+                  <span className='hero-highlight'>Seeing</span>
                   <span>Your CSS</span>
                 </span>
               </h1>
-              <p className="subheadline">
-                Border Patrol is the ultimate visual debugging tool that reveals webpage structures
-                and box models instantly. Visualize element boundaries, margins, and padding with
-                ease!
+              <p className='subheadline'>
+                Border Patrol is the ultimate visual debugging tool that reveals
+                webpage structures and box models instantly. Visualize element
+                boundaries, margins, and padding with ease!
               </p>
-              <p className="cta-description">
-                Say goodbye to CSS debugging frustration and hello to clear, visual understanding.
-                Get the free Chrome extension now!
+              <p className='cta-description'>
+                Say goodbye to CSS debugging frustration and hello to clear,
+                visual understanding. Get the free Chrome extension now!
               </p>
 
-              <div className="cta-buttons">
+              <div className='cta-buttons'>
                 <a
-                  href="https://chromewebstore.google.com/detail/fdkdknepjdabfaihhdljlbbcjiahmkkd?utm_source=item-share-cb"
-                  className="button primary-button"
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  href='https://chromewebstore.google.com/detail/fdkdknepjdabfaihhdljlbbcjiahmkkd?utm_source=item-share-cb'
+                  className='button primary-button'
+                  target='_blank'
+                  rel='noopener noreferrer'
                 >
-                  <i className="fa-brands fa-chrome"></i> Add to Chrome
+                  <i className='fa-brands fa-chrome'></i> Add to Chrome
                 </a>
                 <a
-                  href="https://github.com/seasav/border-patrol"
-                  className="button secondary-button"
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  href='https://github.com/seasav/border-patrol'
+                  className='button secondary-button'
+                  target='_blank'
+                  rel='noopener noreferrer'
                 >
-                  <i className="fa-brands fa-github"></i> View on GitHub
+                  <i className='fa-brands fa-github'></i> View on GitHub
                 </a>
               </div>
             </div>
 
-            <div className="hero-image">
+            <div className='hero-image'>
               <img
-                src="/assets/img/border-patrol-popup-menu.png"
-                alt="Border Patrol Menu Screenshot"
+                src='/assets/img/border-patrol-popup-menu.png'
+                alt='Border Patrol Menu Screenshot'
                 width={568}
                 height={1110}
               />
@@ -79,63 +79,77 @@ export default function HomePage() {
         </div>
       </header>
 
-      <section id="problem-solution" className="section">
-        <div className="container">
-          <div className="section-header">
-            <span className="section-subtitle">The Developer&apos;s Dilemma</span>
+      <section id='problem-solution' className='section'>
+        <div className='container'>
+          <div className='section-header'>
+            <span className='section-subtitle'>
+              The Developer&apos;s Dilemma
+            </span>
             <h2>CSS Debugging Shouldn&apos;t Be a Puzzle</h2>
-            <p className="section-intro">
-              Spend less time hunting CSS issues and more time building amazing interfaces
+            <p className='section-intro'>
+              Spend less time hunting CSS issues and more time building amazing
+              interfaces
             </p>
           </div>
 
-          <div className="problem-solution-grid">
-            <div className="problem-card">
-              <div className="card-header">
-                <i className="fas fa-exclamation-triangle"></i>
+          <div className='problem-solution-grid'>
+            <div className='problem-card'>
+              <div className='card-header'>
+                <i className='fas fa-exclamation-triangle'></i>
                 <h3>The Problem</h3>
               </div>
-              <ul className="problem-list">
+              <ul className='problem-list'>
                 <li>
-                  <i className="fas fa-align-left icon-list"></i>
+                  <i className='fas fa-align-left icon-list'></i>
                   <span>Complex layouts that never quite align</span>
                 </li>
                 <li>
-                  <i className="fas fa-arrows-alt icon-list"></i>
-                  <span>Inconsistent spacing that&apos;s hard to track down</span>
+                  <i className='fas fa-arrows-alt icon-list'></i>
+                  <span>
+                    Inconsistent spacing that&apos;s hard to track down
+                  </span>
                 </li>
                 <li>
-                  <i className="fas fa-layer-group icon-list"></i>
-                  <span>Nested elements making it hard to see the full picture</span>
+                  <i className='fas fa-layer-group icon-list'></i>
+                  <span>
+                    Nested elements making it hard to see the full picture
+                  </span>
                 </li>
                 <li>
-                  <i className="far fa-clock icon-list"></i>
-                  <span>Time wasted toggling between browser and code editor</span>
+                  <i className='far fa-clock icon-list'></i>
+                  <span>
+                    Time wasted toggling between browser and code editor
+                  </span>
                 </li>
               </ul>
             </div>
-            <div className="solution-card">
-              <div className="card-header">
-                <i className="fas fa-lightbulb"></i>
+            <div className='solution-card'>
+              <div className='card-header'>
+                <i className='fas fa-lightbulb'></i>
                 <h3>The Solution</h3>
               </div>
-              <div className="solution-content">
-                <p className="highlight-text">
-                  Border Patrol gives you instant visual feedback on your page&apos;s structure,
-                  making CSS debugging faster and more intuitive.
+              <div className='solution-content'>
+                <p className='highlight-text'>
+                  Border Patrol gives you instant visual feedback on your
+                  page&apos;s structure, making CSS debugging faster and more
+                  intuitive.
                 </p>
-                <ul className="solution-features">
+                <ul className='solution-features'>
                   <li>
-                    <i className="fas fa-check-circle"></i> See element boundaries at a glance
+                    <i className='fas fa-check-circle'></i> See element
+                    boundaries at a glance
                   </li>
                   <li>
-                    <i className="fas fa-check-circle"></i> Visualize margins and padding instantly
+                    <i className='fas fa-check-circle'></i> Visualize margins
+                    and padding instantly
                   </li>
                   <li>
-                    <i className="fas fa-check-circle"></i> No more guesswork in your CSS debugging
+                    <i className='fas fa-check-circle'></i> No more guesswork in
+                    your CSS debugging
                   </li>
                   <li>
-                    <i className="fas fa-check-circle"></i> Save time with real-time visual feedback
+                    <i className='fas fa-check-circle'></i> Save time with
+                    real-time visual feedback
                   </li>
                 </ul>
               </div>
@@ -144,170 +158,179 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section id="features" className="section bg-light">
-        <div className="container">
-          <div className="section-header">
-            <span className="section-subtitle">Powerful Tools at Your Fingertips</span>
+      <section id='features' className='section bg-light'>
+        <div className='container'>
+          <div className='section-header'>
+            <span className='section-subtitle'>
+              Powerful Tools at Your Fingertips
+            </span>
             <h2>Key Features to Boost Your Workflow</h2>
-            <p className="section-intro">
-              Designed with developers in mind, these features will transform how you debug and
-              understand CSS layouts
+            <p className='section-intro'>
+              Designed with developers in mind, these features will transform
+              how you debug and understand CSS layouts
             </p>
           </div>
-          <div className="feature-grid">
-            <div className="card feature-item">
-              <div className="feature-emoji">🎨</div>
+          <div className='feature-grid'>
+            <div className='card feature-item'>
+              <div className='feature-emoji'>🎨</div>
               <h3>Visual Outlining</h3>
               <p>
-                See every HTML element with color-coded outlines at the click of a button or with a
-                shortcut.
+                See every HTML element with color-coded outlines at the click of
+                a button or with a shortcut.
               </p>
             </div>
-            <div className="card feature-item">
-              <div className="feature-emoji">📦</div>
+            <div className='card feature-item'>
+              <div className='feature-emoji'>📦</div>
               <h3>Visualize the Box Model</h3>
               <p>
-                Clearly understand margin, border, and padding with visual representations around
-                each element.
+                Clearly understand margin, border, and padding with visual
+                representations around each element.
               </p>
             </div>
-            <div className="card feature-item">
-              <div className="feature-emoji">🔍</div>
+            <div className='card feature-item'>
+              <div className='feature-emoji'>🔍</div>
               <h3>Element Inspector</h3>
               <p>
-                Hover to see tag name, dimensions, and computed box model properties in a real-time
-                overlay.
+                Hover to see tag name, dimensions, and computed box model
+                properties in a real-time overlay.
               </p>
             </div>
-            <div className="card feature-item">
-              <div className="feature-emoji">🎛️</div>
+            <div className='card feature-item'>
+              <div className='feature-emoji'>🎛️</div>
               <h3>Customize Outlines</h3>
               <p>
-                Tailor the outlines to your preference by easily adjusting their size and style via
-                the extension&apos;s intuitive popup menu.
+                Tailor the outlines to your preference by easily adjusting their
+                size and style via the extension&apos;s intuitive popup menu.
               </p>
             </div>
-            <div className="card feature-item">
-              <div className="feature-emoji">⌨️</div>
+            <div className='card feature-item'>
+              <div className='feature-emoji'>⌨️</div>
               <h3>Toggle with Shortcut</h3>
               <p>
-                Instantly enable/disable Border Patrol with a customizable keyboard shortcut (
-                <code>Alt</code> + <code>Shift</code> + <code>B</code>).
+                Instantly enable/disable Border Patrol with a customizable
+                keyboard shortcut (<code>Alt</code> + <code>Shift</code> +{' '}
+                <code>B</code>).
               </p>
             </div>
-            <div className="card feature-item">
-              <div className="feature-emoji">📸</div>
+            <div className='card feature-item'>
+              <div className='feature-emoji'>📸</div>
               <h3>Screenshot Capture</h3>
               <p>
-                One-click screenshot capture and download. Perfect for layout documentation and
-                feedback sharing.
+                One-click screenshot capture and download. Perfect for layout
+                documentation and feedback sharing.
               </p>
             </div>
           </div>
         </div>
       </section>
 
-      <section id="in-action" className="section">
-        <div className="container">
-          <div className="section-header">
-            <span className="section-subtitle">See It In Action</span>
+      <section id='in-action' className='section'>
+        <div className='container'>
+          <div className='section-header'>
+            <span className='section-subtitle'>See It In Action</span>
             <h2>Visual CSS Debugging at Its Best</h2>
-            <p className="section-intro">
-              Border Patrol makes it easy to visualize and debug your layouts with just one click
+            <p className='section-intro'>
+              Border Patrol makes it easy to visualize and debug your layouts
+              with just one click
             </p>
           </div>
 
-          <div className="screenshot-container">
+          <div className='screenshot-container'>
             <img
-              src="/assets/img/border-patrol-demo-picture.png"
-              alt="Border Patrol Extension in Action"
-              className="screenshot"
-              loading="lazy"
+              src='/assets/img/border-patrol-demo-picture.png'
+              alt='Border Patrol Extension in Action'
+              className='screenshot'
+              loading='lazy'
             />
           </div>
 
-          <div className="screenshot-caption">
+          <div className='screenshot-caption'>
             <p>
-              Border Patrol highlights all HTML elements with color-coded borders, making it easy to
-              identify spacing and layout issues.
+              Border Patrol highlights all HTML elements with color-coded
+              borders, making it easy to identify spacing and layout issues.
             </p>
           </div>
         </div>
       </section>
 
-      <section id="benefits" className="section">
-        <div className="container">
-          <div className="section-header">
-            <span className="section-subtitle">Why Developers Love Border Patrol</span>
+      <section id='benefits' className='section'>
+        <div className='container'>
+          <div className='section-header'>
+            <span className='section-subtitle'>
+              Why Developers Love Border Patrol
+            </span>
             <h2>Supercharge Your CSS Workflow</h2>
-            <p className="section-intro">
-              Experience the difference with powerful features designed to make CSS debugging a
-              breeze
+            <p className='section-intro'>
+              Experience the difference with powerful features designed to make
+              CSS debugging a breeze
             </p>
           </div>
 
-          <div className="benefits-grid">
-            <div className="card benefit-card">
-              <div className="benefit-icon">🚀</div>
+          <div className='benefits-grid'>
+            <div className='card benefit-card'>
+              <div className='benefit-icon'>🚀</div>
               <h3>Lightning-Fast Debugging</h3>
               <p>
-                Pinpoint layout issues in seconds with instant visual feedback, reducing debugging
-                time by up to 70%.
+                Pinpoint layout issues in seconds with instant visual feedback,
+                reducing debugging time by up to 70%.
               </p>
             </div>
-            <div className="card benefit-card">
-              <div className="benefit-icon">🎯</div>
+            <div className='card benefit-card'>
+              <div className='benefit-icon'>🎯</div>
               <h3>Pixel-Perfect Precision</h3>
               <p>
-                Visualize margins, padding, and borders with surgical precision for pixel-perfect
-                implementations.
+                Visualize margins, padding, and borders with surgical precision
+                for pixel-perfect implementations.
               </p>
             </div>
-            <div className="card benefit-card">
-              <div className="benefit-icon">🤝</div>
+            <div className='card benefit-card'>
+              <div className='benefit-icon'>🤝</div>
               <h3>Seamless Collaboration</h3>
               <p>
-                Easily communicate issues with team members using visual references everyone can
-                understand.
+                Easily communicate issues with team members using visual
+                references everyone can understand.
               </p>
             </div>
-            <div className="card benefit-card">
-              <div className="benefit-icon">⚡</div>
+            <div className='card benefit-card'>
+              <div className='benefit-icon'>⚡</div>
               <h3>Zero Performance Impact</h3>
               <p>
-                Lightweight implementation that won&apos;t slow down your development workflow or
-                browser performance.
+                Lightweight implementation that won&apos;t slow down your
+                development workflow or browser performance.
               </p>
             </div>
-            <div className="card benefit-card">
-              <div className="benefit-icon">🔍</div>
+            <div className='card benefit-card'>
+              <div className='benefit-icon'>🔍</div>
               <h3>Deep Element Insights</h3>
               <p>
-                Quickly identify nested elements and understand complex component hierarchies at a
-                glance.
+                Quickly identify nested elements and understand complex
+                component hierarchies at a glance.
               </p>
             </div>
-            <div className="card benefit-card">
-              <div className="benefit-icon">🎨</div>
+            <div className='card benefit-card'>
+              <div className='benefit-icon'>🎨</div>
               <h3>Customizable Visuals</h3>
               <p>
-                Tailor the visualization to match your workflow with customizable colors and display
-                options.
+                Tailor the visualization to match your workflow with
+                customizable colors and display options.
               </p>
             </div>
           </div>
         </div>
       </section>
 
-      <section id="call-to-action" className="cta-section">
-        <div className="container">
+      <section id='call-to-action' className='cta-section'>
+        <div className='container'>
           <h2>Ready to Experience Effortless CSS Debugging?</h2>
-          <p>Add Border Patrol to Chrome today and revolutionize the way you work with CSS.</p>
+          <p>
+            Add Border Patrol to Chrome today and revolutionize the way you work
+            with CSS.
+          </p>
           <a
-            href="https://chromewebstore.google.com/detail/fdkdknepjdabfaihhdljlbbcjiahmkkd?utm_source=item-share-cb"
-            className="button primary-button large-button"
-            target="_blank"
-            rel="noopener noreferrer"
+            href='https://chromewebstore.google.com/detail/fdkdknepjdabfaihhdljlbbcjiahmkkd?utm_source=item-share-cb'
+            className='button primary-button large-button'
+            target='_blank'
+            rel='noopener noreferrer'
           >
             Get Border Patrol - It&apos;s Free
           </a>

--- a/landing/app/privacy/page.tsx
+++ b/landing/app/privacy/page.tsx
@@ -13,86 +13,110 @@ export const metadata: Metadata = {
   },
 };
 
+const sectionHeading: React.CSSProperties = {
+  textAlign: 'left',
+  fontSize: '1.2rem',
+  fontWeight: 700,
+  color: 'var(--bp-blue-900)',
+  marginTop: '2.5rem',
+  marginBottom: '0.75rem',
+  paddingBottom: '0.5rem',
+  borderBottom: '2px solid var(--bp-blue-200)',
+};
+
 export default function PrivacyPage() {
   return (
     <>
       <Nav />
-      <main className="container" style={{ paddingTop: '3rem', paddingBottom: '4rem', maxWidth: '760px' }}>
-        <h1 style={{ marginBottom: '0.5rem' }}>Privacy Policy</h1>
-        <p style={{ color: 'var(--light-text-color)', marginBottom: '2.5rem' }}>
-          Last updated: April 13, 2026
+
+      <div style={{ borderBottom: '1px solid var(--border-color)', background: 'var(--card-background)' }}>
+        <div className="container" style={{ paddingTop: '3rem', paddingBottom: '3rem' }}>
+          <p style={{ fontSize: '0.85rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '1px', color: 'var(--bp-blue-500)', marginBottom: '0.75rem' }}>
+            Legal
+          </p>
+          <h1 style={{ fontSize: '2.5rem', marginBottom: '0.5rem' }}>Privacy Policy</h1>
+          <p style={{ color: 'var(--light-text-color)', marginBottom: 0 }}>
+            Last updated: April 14, 2026 &nbsp;·&nbsp; Applies to the Border Patrol Chrome extension and this website
+          </p>
+        </div>
+      </div>
+
+      <main className="container" style={{ paddingTop: '2.5rem', paddingBottom: '5rem' }}>
+        <p style={{ fontSize: '1.1rem', lineHeight: 1.8, maxWidth: '800px' }}>
+          Border Patrol is a developer tool — nothing more. It does not have a backend, does not create
+          accounts, and does not communicate with any server. This policy explains what the extension
+          accesses and why, in plain language.
         </p>
 
-        <p style={{ marginBottom: '1.5rem' }}>
-          Border Patrol is a free, open-source Chrome extension developed by SeaSav Labs Inc. This
-          policy explains what data the extension accesses and how it is handled.
+        <h2 style={sectionHeading}>The short version</h2>
+        <p>
+          Border Patrol collects absolutely no personal data. Everything the extension does happens
+          locally in your browser. No information about you, the pages you visit, or your debugging
+          sessions is ever sent anywhere.
         </p>
 
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Data We Do Not Collect</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          Border Patrol does <strong>not</strong>:
+        <h2 style={sectionHeading}>What the extension accesses</h2>
+        <p>
+          To do its job, Border Patrol reads the DOM structure of the active tab. This is how it
+          draws outlines around elements, computes margin and padding overlays, and displays
+          inspector data. This access is scoped to the current tab and is never stored beyond your
+          browser session, and never transmitted.
         </p>
-        <ul style={{ paddingLeft: '1.5rem', marginBottom: '1.5rem', lineHeight: '1.8' }}>
-          <li>Collect, transmit, or store any personal information</li>
-          <li>Send any data to external servers or third parties</li>
-          <li>Track your browsing history or the pages you visit</li>
-          <li>Use analytics or advertising SDKs</li>
-          <li>Require account registration of any kind</li>
-        </ul>
-
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>What the Extension Accesses</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          To provide its visual debugging features, Border Patrol reads the DOM structure of the
-          active tab. This is used solely to render outlines, margin/padding overlays, and the
-          element inspector on your screen. This information is processed entirely within your
-          browser and is never transmitted anywhere.
+        <p>
+          The screenshot feature uses Chrome&apos;s built-in capture API via an offscreen document.
+          The image is rendered in memory and immediately downloaded to your device. No screenshot
+          data is held in extension storage or sent anywhere.
         </p>
 
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Local Storage</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          The extension saves your preferences (such as border size, style, and feature state) to{' '}
-          <code>chrome.storage.local</code> on your device. This data never leaves your browser and
-          is only used to restore your settings between sessions.
+        <h2 style={sectionHeading}>Local storage</h2>
+        <p>
+          The extension uses <code>chrome.storage.local</code> to remember your preferences between
+          sessions — things like your chosen border size, style, and which features are active. This
+          data lives only in your browser. It is never synced to a server, and SeaSav Labs Inc. has
+          no access to it.
         </p>
 
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Screenshots</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          When you use the screenshot capture feature, the image is generated and downloaded directly
-          to your device. No screenshot data is uploaded or shared.
+        <h2 style={sectionHeading}>This website</h2>
+        <p>
+          This landing page is a static Next.js site. It does not use cookies, tracking pixels,
+          session identifiers, or any analytics service. There is no login, no form submission, and
+          no data collected from visitors.
         </p>
 
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Third-Party Services</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          This landing page is hosted as a static site. It does not use cookies, tracking pixels, or
-          third-party analytics.
+        <h2 style={sectionHeading}>Third parties</h2>
+        <p>
+          Border Patrol has no third-party integrations. It does not include advertising SDKs,
+          crash reporting services, or telemetry of any kind.
         </p>
 
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Open Source</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          Border Patrol is fully open source. You can inspect the complete source code at{' '}
-          <a
-            href="https://github.com/seasav/border-patrol"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+        <h2 style={sectionHeading}>Open source &amp; transparency</h2>
+        <p>
+          Border Patrol is open source and developed in the open at{' '}
+          <a href="https://github.com/seasav/border-patrol" target="_blank" rel="noopener noreferrer">
             github.com/seasav/border-patrol
           </a>
-          .
+          . The source code is public so the community can audit exactly what the extension does,
+          report issues, and contribute improvements. The code and all Border Patrol branding remain
+          the property of SeaSav Labs Inc.
         </p>
 
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Contact</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          If you have questions about this policy, please open an issue on the{' '}
-          <a
-            href="https://github.com/seasav/border-patrol/issues"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+        <h2 style={sectionHeading}>Changes to this policy</h2>
+        <p>
+          If we ever change this policy, the updated version will be posted here with a revised
+          date. Given that Border Patrol does not collect data, we don&apos;t anticipate meaningful
+          changes.
+        </p>
+
+        <h2 style={sectionHeading}>Contact</h2>
+        <p>
+          Questions or concerns? Open an issue on the{' '}
+          <a href="https://github.com/seasav/border-patrol/issues" target="_blank" rel="noopener noreferrer">
             GitHub repository
           </a>
           .
         </p>
       </main>
+
       <Footer />
     </>
   );

--- a/landing/app/privacy/page.tsx
+++ b/landing/app/privacy/page.tsx
@@ -29,88 +29,125 @@ export default function PrivacyPage() {
     <>
       <Nav />
 
-      <div style={{ borderBottom: '1px solid var(--border-color)', background: 'var(--card-background)' }}>
-        <div className="container" style={{ paddingTop: '3rem', paddingBottom: '3rem' }}>
-          <p style={{ fontSize: '0.85rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '1px', color: 'var(--bp-blue-500)', marginBottom: '0.75rem' }}>
+      <div
+        style={{
+          borderBottom: '1px solid var(--border-color)',
+          background: 'var(--card-background)',
+        }}
+      >
+        <div
+          className='container'
+          style={{ paddingTop: '3rem', paddingBottom: '3rem' }}
+        >
+          <p
+            style={{
+              fontSize: '0.85rem',
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: '1px',
+              color: 'var(--bp-blue-500)',
+              marginBottom: '0.75rem',
+            }}
+          >
             Legal
           </p>
-          <h1 style={{ fontSize: '2.5rem', marginBottom: '0.5rem' }}>Privacy Policy</h1>
+          <h1 style={{ fontSize: '2.5rem', marginBottom: '0.5rem' }}>
+            Privacy Policy
+          </h1>
           <p style={{ color: 'var(--light-text-color)', marginBottom: 0 }}>
-            Last updated: April 14, 2026 &nbsp;·&nbsp; Applies to the Border Patrol Chrome extension and this website
+            Last updated: April 14, 2026 &nbsp;·&nbsp; Applies to the Border
+            Patrol Chrome extension and this website
           </p>
         </div>
       </div>
 
-      <main className="container" style={{ paddingTop: '2.5rem', paddingBottom: '5rem' }}>
+      <main
+        className='container'
+        style={{ paddingTop: '2.5rem', paddingBottom: '5rem' }}
+      >
         <p style={{ fontSize: '1.1rem', lineHeight: 1.8, maxWidth: '800px' }}>
-          Border Patrol is a developer tool — nothing more. It does not have a backend, does not create
-          accounts, and does not communicate with any server. This policy explains what the extension
-          accesses and why, in plain language.
+          Border Patrol is a developer tool — nothing more. It does not have a
+          backend, does not create accounts, and does not communicate with any
+          server. This policy explains what the extension accesses and why, in
+          plain language.
         </p>
 
         <h2 style={sectionHeading}>The short version</h2>
         <p>
-          Border Patrol collects absolutely no personal data. Everything the extension does happens
-          locally in your browser. No information about you, the pages you visit, or your debugging
-          sessions is ever sent anywhere.
+          Border Patrol collects absolutely no personal data. Everything the
+          extension does happens locally in your browser. No information about
+          you, the pages you visit, or your debugging sessions is ever sent
+          anywhere.
         </p>
 
         <h2 style={sectionHeading}>What the extension accesses</h2>
         <p>
-          To do its job, Border Patrol reads the DOM structure of the active tab. This is how it
-          draws outlines around elements, computes margin and padding overlays, and displays
-          inspector data. This access is scoped to the current tab and is never stored beyond your
-          browser session, and never transmitted.
+          To do its job, Border Patrol reads the DOM structure of the active
+          tab. This is how it draws outlines around elements, computes margin
+          and padding overlays, and displays inspector data. This access is
+          scoped to the current tab and is never stored beyond your browser
+          session, and never transmitted.
         </p>
         <p>
-          The screenshot feature uses Chrome&apos;s built-in capture API via an offscreen document.
-          The image is rendered in memory and immediately downloaded to your device. No screenshot
-          data is held in extension storage or sent anywhere.
+          The screenshot feature uses Chrome&apos;s built-in capture API via an
+          offscreen document. The image is rendered in memory and immediately
+          downloaded to your device. No screenshot data is held in extension
+          storage or sent anywhere.
         </p>
 
         <h2 style={sectionHeading}>Local storage</h2>
         <p>
-          The extension uses <code>chrome.storage.local</code> to remember your preferences between
-          sessions — things like your chosen border size, style, and which features are active. This
-          data lives only in your browser. It is never synced to a server, and SeaSav Labs Inc. has
-          no access to it.
+          The extension uses <code>chrome.storage.local</code> to remember your
+          preferences between sessions — things like your chosen border size,
+          style, and which features are active. This data lives only in your
+          browser. It is never synced to a server, and SeaSav Labs Inc. has no
+          access to it.
         </p>
 
         <h2 style={sectionHeading}>This website</h2>
         <p>
-          This landing page is a static Next.js site. It does not use cookies, tracking pixels,
-          session identifiers, or any analytics service. There is no login, no form submission, and
-          no data collected from visitors.
+          This landing page is a static Next.js site. It does not use cookies,
+          tracking pixels, session identifiers, or any analytics service. There
+          is no login, no form submission, and no data collected from visitors.
         </p>
 
         <h2 style={sectionHeading}>Third parties</h2>
         <p>
-          Border Patrol has no third-party integrations. It does not include advertising SDKs,
-          crash reporting services, or telemetry of any kind.
+          Border Patrol has no third-party integrations. It does not include
+          advertising SDKs, crash reporting services, or telemetry of any kind.
         </p>
 
         <h2 style={sectionHeading}>Open source &amp; transparency</h2>
         <p>
           Border Patrol is open source and developed in the open at{' '}
-          <a href="https://github.com/seasav/border-patrol" target="_blank" rel="noopener noreferrer">
+          <a
+            href='https://github.com/seasav/border-patrol'
+            target='_blank'
+            rel='noopener noreferrer'
+          >
             github.com/seasav/border-patrol
           </a>
-          . The source code is public so the community can audit exactly what the extension does,
-          report issues, and contribute improvements. The code and all Border Patrol branding remain
-          the property of SeaSav Labs Inc.
+          . The source code is public so the community can audit exactly what
+          the extension does, report issues, and contribute improvements. The
+          code and all Border Patrol branding remain the property of SeaSav Labs
+          Inc.
         </p>
 
         <h2 style={sectionHeading}>Changes to this policy</h2>
         <p>
-          If we ever change this policy, the updated version will be posted here with a revised
-          date. Given that Border Patrol does not collect data, we don&apos;t anticipate meaningful
-          changes.
+          If we ever change this policy, the updated version will be posted here
+          with a revised date. Given that Border Patrol does not collect data,
+          we don&apos;t anticipate meaningful changes.
         </p>
 
         <h2 style={sectionHeading}>Contact</h2>
         <p>
           Questions or concerns? Open an issue on the{' '}
-          <a href="https://github.com/seasav/border-patrol/issues" target="_blank" rel="noopener noreferrer">
+          <a
+            href='https://github.com/seasav/border-patrol/issues'
+            target='_blank'
+            rel='noopener noreferrer'
+          >
             GitHub repository
           </a>
           .

--- a/landing/app/privacy/page.tsx
+++ b/landing/app/privacy/page.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import type { Metadata } from 'next';
 import Nav from '../../components/Nav';
 import Footer from '../../components/Footer';
@@ -13,7 +14,7 @@ export const metadata: Metadata = {
   },
 };
 
-const sectionHeading: React.CSSProperties = {
+const sectionHeading: CSSProperties = {
   textAlign: 'left',
   fontSize: '1.2rem',
   fontWeight: 700,

--- a/landing/app/privacy/page.tsx
+++ b/landing/app/privacy/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from 'next';
+import Nav from '../../components/Nav';
+import Footer from '../../components/Footer';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy - Border Patrol',
+  description: 'Privacy policy for the Border Patrol Chrome extension.',
+  alternates: { canonical: 'https://border-patrol.seasav.ca/privacy/' },
+  openGraph: {
+    url: 'https://border-patrol.seasav.ca/privacy/',
+    title: 'Privacy Policy - Border Patrol',
+    description: 'Privacy policy for the Border Patrol Chrome extension.',
+  },
+};
+
+export default function PrivacyPage() {
+  return (
+    <>
+      <Nav />
+      <main className="container" style={{ paddingTop: '3rem', paddingBottom: '4rem', maxWidth: '760px' }}>
+        <h1 style={{ marginBottom: '0.5rem' }}>Privacy Policy</h1>
+        <p style={{ color: 'var(--light-text-color)', marginBottom: '2.5rem' }}>
+          Last updated: April 13, 2026
+        </p>
+
+        <p style={{ marginBottom: '1.5rem' }}>
+          Border Patrol is a free, open-source Chrome extension developed by SeaSav Labs Inc. This
+          policy explains what data the extension accesses and how it is handled.
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Data We Do Not Collect</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          Border Patrol does <strong>not</strong>:
+        </p>
+        <ul style={{ paddingLeft: '1.5rem', marginBottom: '1.5rem', lineHeight: '1.8' }}>
+          <li>Collect, transmit, or store any personal information</li>
+          <li>Send any data to external servers or third parties</li>
+          <li>Track your browsing history or the pages you visit</li>
+          <li>Use analytics or advertising SDKs</li>
+          <li>Require account registration of any kind</li>
+        </ul>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>What the Extension Accesses</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          To provide its visual debugging features, Border Patrol reads the DOM structure of the
+          active tab. This is used solely to render outlines, margin/padding overlays, and the
+          element inspector on your screen. This information is processed entirely within your
+          browser and is never transmitted anywhere.
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Local Storage</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          The extension saves your preferences (such as border size, style, and feature state) to{' '}
+          <code>chrome.storage.local</code> on your device. This data never leaves your browser and
+          is only used to restore your settings between sessions.
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Screenshots</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          When you use the screenshot capture feature, the image is generated and downloaded directly
+          to your device. No screenshot data is uploaded or shared.
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Third-Party Services</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          This landing page is hosted as a static site. It does not use cookies, tracking pixels, or
+          third-party analytics.
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Open Source</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          Border Patrol is fully open source. You can inspect the complete source code at{' '}
+          <a
+            href="https://github.com/seasav/border-patrol"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            github.com/seasav/border-patrol
+          </a>
+          .
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Contact</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          If you have questions about this policy, please open an issue on the{' '}
+          <a
+            href="https://github.com/seasav/border-patrol/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub repository
+          </a>
+          .
+        </p>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/landing/app/terms/page.tsx
+++ b/landing/app/terms/page.tsx
@@ -69,7 +69,7 @@ export default function TermsPage() {
             target="_blank"
             rel="noopener noreferrer"
           >
-            MIT License
+            Apache 2.0 License
           </a>
           , but all intellectual property rights — including the source code, the Border Patrol name,
           and all associated branding and assets — remain the exclusive property of SeaSav Labs Inc.

--- a/landing/app/terms/page.tsx
+++ b/landing/app/terms/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from 'next';
+import Nav from '../../components/Nav';
+import Footer from '../../components/Footer';
+
+export const metadata: Metadata = {
+  title: 'Terms of Use - Border Patrol',
+  description: 'Terms of use for the Border Patrol Chrome extension.',
+  alternates: { canonical: 'https://border-patrol.seasav.ca/terms/' },
+  openGraph: {
+    url: 'https://border-patrol.seasav.ca/terms/',
+    title: 'Terms of Use - Border Patrol',
+    description: 'Terms of use for the Border Patrol Chrome extension.',
+  },
+};
+
+export default function TermsPage() {
+  return (
+    <>
+      <Nav />
+      <main className="container" style={{ paddingTop: '3rem', paddingBottom: '4rem', maxWidth: '760px' }}>
+        <h1 style={{ marginBottom: '0.5rem' }}>Terms of Use</h1>
+        <p style={{ color: 'var(--light-text-color)', marginBottom: '2.5rem' }}>
+          Last updated: April 13, 2026
+        </p>
+
+        <p style={{ marginBottom: '1.5rem' }}>
+          By installing or using the Border Patrol Chrome extension (&ldquo;the Extension&rdquo;),
+          you agree to the following terms. The Extension is developed and maintained by SeaSav Labs
+          Inc. (&ldquo;we&rdquo;, &ldquo;us&rdquo;).
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>License</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          Border Patrol is open-source software released under the{' '}
+          <a
+            href="https://github.com/seasav/border-patrol/blob/main/LICENSE"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            MIT License
+          </a>
+          . You are free to use, copy, modify, and distribute it in accordance with the terms of
+          that license.
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Intended Use</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          The Extension is a developer tool intended to assist with CSS layout debugging and
+          inspection. It is provided for lawful, personal or professional development use only. You
+          agree not to use the Extension for any purpose that violates applicable laws or the terms
+          of any third-party service.
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>No Warranty</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          The Extension is provided &ldquo;as is&rdquo;, without warranty of any kind, express or
+          implied. We make no guarantees regarding availability, accuracy, or fitness for a
+          particular purpose. Use at your own risk.
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Limitation of Liability</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          To the fullest extent permitted by law, SeaSav Labs Inc. shall not be liable for any
+          direct, indirect, incidental, or consequential damages arising from your use of or
+          inability to use the Extension.
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Changes</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          We may update these terms from time to time. Continued use of the Extension after changes
+          are posted constitutes acceptance of the revised terms. The &ldquo;last updated&rdquo;
+          date at the top of this page will reflect any changes.
+        </p>
+
+        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Contact</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          Questions about these terms can be directed to the{' '}
+          <a
+            href="https://github.com/seasav/border-patrol/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub repository
+          </a>
+          .
+        </p>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/landing/app/terms/page.tsx
+++ b/landing/app/terms/page.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import type { Metadata } from 'next';
 import Nav from '../../components/Nav';
 import Footer from '../../components/Footer';
@@ -13,7 +14,7 @@ export const metadata: Metadata = {
   },
 };
 
-const sectionHeading: React.CSSProperties = {
+const sectionHeading: CSSProperties = {
   textAlign: 'left',
   fontSize: '1.2rem',
   fontWeight: 700,

--- a/landing/app/terms/page.tsx
+++ b/landing/app/terms/page.tsx
@@ -13,25 +13,56 @@ export const metadata: Metadata = {
   },
 };
 
+const sectionHeading: React.CSSProperties = {
+  textAlign: 'left',
+  fontSize: '1.2rem',
+  fontWeight: 700,
+  color: 'var(--bp-blue-900)',
+  marginTop: '2.5rem',
+  marginBottom: '0.75rem',
+  paddingBottom: '0.5rem',
+  borderBottom: '2px solid var(--bp-blue-200)',
+};
+
 export default function TermsPage() {
   return (
     <>
       <Nav />
-      <main className="container" style={{ paddingTop: '3rem', paddingBottom: '4rem', maxWidth: '760px' }}>
-        <h1 style={{ marginBottom: '0.5rem' }}>Terms of Use</h1>
-        <p style={{ color: 'var(--light-text-color)', marginBottom: '2.5rem' }}>
-          Last updated: April 13, 2026
+
+      <div style={{ borderBottom: '1px solid var(--border-color)', background: 'var(--card-background)' }}>
+        <div className="container" style={{ paddingTop: '3rem', paddingBottom: '3rem' }}>
+          <p style={{ fontSize: '0.85rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '1px', color: 'var(--bp-blue-500)', marginBottom: '0.75rem' }}>
+            Legal
+          </p>
+          <h1 style={{ fontSize: '2.5rem', marginBottom: '0.5rem' }}>Terms of Use</h1>
+          <p style={{ color: 'var(--light-text-color)', marginBottom: 0 }}>
+            Last updated: April 14, 2026 &nbsp;·&nbsp; Applies to the Border Patrol Chrome extension and this website
+          </p>
+        </div>
+      </div>
+
+      <main className="container" style={{ paddingTop: '2.5rem', paddingBottom: '5rem' }}>
+        <p style={{ fontSize: '1.1rem', lineHeight: 1.8, maxWidth: '800px' }}>
+          Border Patrol is free, open-source software made for developers. These terms are intentionally
+          brief — we want you to use the extension, not read legalese. By installing or using Border
+          Patrol, you agree to the terms below.
         </p>
 
-        <p style={{ marginBottom: '1.5rem' }}>
-          By installing or using the Border Patrol Chrome extension (&ldquo;the Extension&rdquo;),
-          you agree to the following terms. The Extension is developed and maintained by SeaSav Labs
-          Inc. (&ldquo;we&rdquo;, &ldquo;us&rdquo;).
+        <h2 style={sectionHeading}>Open source &amp; intellectual property</h2>
+        <p>
+          Border Patrol is developed in the open and welcomes community contributions. The source
+          code is available on{' '}
+          <a
+            href="https://github.com/seasav/border-patrol"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </a>{' '}
+          — bug reports, feature suggestions, and pull requests are encouraged.
         </p>
-
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>License</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          Border Patrol is open-source software released under the{' '}
+        <p>
+          The codebase is licensed under the{' '}
           <a
             href="https://github.com/seasav/border-patrol/blob/main/LICENSE"
             target="_blank"
@@ -39,42 +70,51 @@ export default function TermsPage() {
           >
             MIT License
           </a>
-          . You are free to use, copy, modify, and distribute it in accordance with the terms of
-          that license.
+          , but all intellectual property rights — including the source code, the Border Patrol name,
+          and all associated branding and assets — remain the exclusive property of SeaSav Labs Inc.
+          The MIT License governs how the code may be used and contributed to; it does not transfer
+          ownership or grant rights to the Border Patrol brand.
         </p>
 
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Intended Use</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          The Extension is a developer tool intended to assist with CSS layout debugging and
-          inspection. It is provided for lawful, personal or professional development use only. You
-          agree not to use the Extension for any purpose that violates applicable laws or the terms
-          of any third-party service.
+        <h2 style={sectionHeading}>Intended use</h2>
+        <p>
+          Border Patrol is a visual debugging tool for web developers. It is intended for inspecting
+          CSS layouts on pages you own or have permission to inspect. You agree to use it only for
+          lawful purposes and in accordance with the terms of any third-party service or platform you
+          apply it to.
         </p>
 
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>No Warranty</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          The Extension is provided &ldquo;as is&rdquo;, without warranty of any kind, express or
-          implied. We make no guarantees regarding availability, accuracy, or fitness for a
-          particular purpose. Use at your own risk.
+        <h2 style={sectionHeading}>No warranty</h2>
+        <p>
+          The extension is provided &ldquo;as is&rdquo;, without warranty of any kind. SeaSav Labs
+          Inc. makes no guarantees about uptime, accuracy, or fitness for a particular purpose. While
+          we work hard to keep it reliable, you use it at your own risk.
         </p>
 
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Limitation of Liability</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          To the fullest extent permitted by law, SeaSav Labs Inc. shall not be liable for any
-          direct, indirect, incidental, or consequential damages arising from your use of or
-          inability to use the Extension.
+        <h2 style={sectionHeading}>Limitation of liability</h2>
+        <p>
+          To the fullest extent permitted by applicable law, SeaSav Labs Inc. shall not be liable for
+          any direct, indirect, incidental, special, or consequential damages arising from your use
+          of or inability to use the extension or this website.
         </p>
 
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Changes</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          We may update these terms from time to time. Continued use of the Extension after changes
-          are posted constitutes acceptance of the revised terms. The &ldquo;last updated&rdquo;
-          date at the top of this page will reflect any changes.
+        <h2 style={sectionHeading}>Third-party platforms</h2>
+        <p>
+          Border Patrol is distributed through the Chrome Web Store, which is governed by
+          Google&apos;s own terms of service. These terms apply only to Border Patrol itself and do
+          not alter your relationship with Google or any other platform.
         </p>
 
-        <h2 style={{ marginBottom: '0.75rem', marginTop: '2rem' }}>Contact</h2>
-        <p style={{ marginBottom: '1rem' }}>
-          Questions about these terms can be directed to the{' '}
+        <h2 style={sectionHeading}>Changes</h2>
+        <p>
+          We may update these terms from time to time. Changes will be posted on this page with a
+          revised date. Continued use of the extension after changes are published constitutes
+          acceptance of the updated terms.
+        </p>
+
+        <h2 style={sectionHeading}>Contact</h2>
+        <p>
+          Questions about these terms can be raised by opening an issue on the{' '}
           <a
             href="https://github.com/seasav/border-patrol/issues"
             target="_blank"
@@ -85,6 +125,7 @@ export default function TermsPage() {
           .
         </p>
       </main>
+
       <Footer />
     </>
   );

--- a/landing/components/Footer.tsx
+++ b/landing/components/Footer.tsx
@@ -3,15 +3,43 @@ import Link from 'next/link';
 export default function Footer() {
   return (
     <footer>
-      <div className="container">
-        <p>
-          &copy; 2026 Border Patrol. Developed by SeaSav Labs Inc.{' '}
-          <Link href="/changelog/">Changelog</Link>
-          {' · '}
-          <Link href="/privacy/">Privacy Policy</Link>
-          {' · '}
-          <Link href="/terms/">Terms of Use</Link>
-        </p>
+      <div className="footer-top">
+        <div className="container">
+          <div className="footer-layout">
+            <div className="footer-brand">
+              <Link href="/" className="footer-brand-link">
+                <img
+                  src="/assets/img/border-patrol-logo.svg"
+                  alt="Border Patrol Logo"
+                  width={28}
+                  height={28}
+                />
+                <span className="footer-brand-name">Border Patrol</span>
+              </Link>
+              <p className="footer-tagline">&ldquo;Stop guessing, start seeing.&rdquo;</p>
+            </div>
+
+            <nav className="footer-links">
+              <Link href="/changelog/">Changelog</Link>
+              <Link href="/privacy/">Privacy Policy</Link>
+              <Link href="/terms/">Terms of Use</Link>
+              <a
+                href="https://seasav.ca"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="footer-company-link"
+              >
+                SeaSav Labs Inc. &rarr;
+              </a>
+            </nav>
+          </div>
+        </div>
+      </div>
+
+      <div className="footer-bottom">
+        <div className="container">
+          <p>&copy; 2026 SeaSav Labs Inc. All rights reserved.</p>
+        </div>
       </div>
     </footer>
   );

--- a/landing/components/Footer.tsx
+++ b/landing/components/Footer.tsx
@@ -3,42 +3,44 @@ import Link from 'next/link';
 export default function Footer() {
   return (
     <footer>
-      <div className="footer-top">
-        <div className="container">
-          <div className="footer-layout">
-            <div className="footer-brand">
-              <Link href="/" className="footer-brand-link">
+      <div className='footer-top'>
+        <div className='container'>
+          <div className='footer-layout'>
+            <div className='footer-brand'>
+              <Link href='/' className='footer-brand-link'>
                 <img
-                  src="/assets/img/border-patrol-logo.svg"
-                  alt="Border Patrol Logo"
+                  src='/assets/img/border-patrol-logo.svg'
+                  alt='Border Patrol Logo'
                   width={28}
                   height={28}
                 />
-                <span className="footer-brand-name">Border Patrol</span>
+                <span className='footer-brand-name'>Border Patrol</span>
               </Link>
-              <p className="footer-tagline">&ldquo;Stop guessing, start seeing.&rdquo;</p>
+              <p className='footer-tagline'>Stop Guessing, Start Seeing!</p>
             </div>
 
-            <nav className="footer-links">
-              <Link href="/changelog/">Changelog</Link>
-              <Link href="/privacy/">Privacy Policy</Link>
-              <Link href="/terms/">Terms of Use</Link>
-              <a
-                href="https://seasav.ca"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="footer-company-link"
-              >
-                SeaSav Labs Inc. &rarr;
-              </a>
+            <nav className='footer-links'>
+              <Link href='/changelog/'>Changelog</Link>
+              <Link href='/privacy/'>Privacy Policy</Link>
+              <Link href='/terms/'>Terms of Use</Link>
             </nav>
           </div>
         </div>
       </div>
 
-      <div className="footer-bottom">
-        <div className="container">
-          <p>&copy; 2026 SeaSav Labs Inc. All rights reserved.</p>
+      <div className='footer-bottom'>
+        <div className='container'>
+          <p>
+            &copy; 2026 Border Patrol by{' '}
+            <a
+              href='https://seasav.ca'
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              SeaSav Labs Inc.
+            </a>{' '}
+            All rights reserved.
+          </p>
         </div>
       </div>
     </footer>

--- a/landing/components/Footer.tsx
+++ b/landing/components/Footer.tsx
@@ -7,6 +7,10 @@ export default function Footer() {
         <p>
           &copy; 2026 Border Patrol. Developed by SeaSav Labs Inc.{' '}
           <Link href="/changelog/">Changelog</Link>
+          {' · '}
+          <Link href="/privacy/">Privacy Policy</Link>
+          {' · '}
+          <Link href="/terms/">Terms of Use</Link>
         </p>
       </div>
     </footer>

--- a/landing/components/Nav.tsx
+++ b/landing/components/Nav.tsx
@@ -2,27 +2,27 @@ import Link from 'next/link';
 
 export default function Nav() {
   return (
-    <nav className="main-nav">
-      <div className="nav-container">
-        <div className="nav-content">
-          <div className="nav-brand">
-            <Link href="/">
+    <nav className='main-nav'>
+      <div className='nav-container'>
+        <div className='nav-content'>
+          <div className='nav-brand'>
+            <Link href='/'>
               <img
-                src="/assets/img/border-patrol-logo.svg"
-                alt="Border Patrol Logo"
-                className="nav-logo"
+                src='/assets/img/border-patrol-logo.svg'
+                alt='Border Patrol Logo'
+                className='nav-logo'
                 width={32}
                 height={32}
               />
-              <span className="nav-title">Border Patrol</span>
+              <span className='nav-title'>Border Patrol</span>
             </Link>
           </div>
-          <div className="nav-cta">
+          <div className='nav-cta'>
             <a
-              href="https://chromewebstore.google.com/detail/fdkdknepjdabfaihhdljlbbcjiahmkkd?utm_source=item-share-cb"
-              className="nav-button button"
-              target="_blank"
-              rel="noopener noreferrer"
+              href='https://chromewebstore.google.com/detail/fdkdknepjdabfaihhdljlbbcjiahmkkd?utm_source=item-share-cb'
+              className='nav-button button'
+              target='_blank'
+              rel='noopener noreferrer'
             >
               Get Border Patrol
             </a>

--- a/landing/next-env.d.ts
+++ b/landing/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/craigsavage/border-patrol.git"
+    "url": "git+https://github.com/seasav/border-patrol.git"
   },
   "keywords": [
     "border",
@@ -32,9 +32,9 @@
   "author": "Craig Savage",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/craigsavage/border-patrol/issues"
+    "url": "https://github.com/seasav/border-patrol/issues"
   },
-  "homepage": "https://github.com/craigsavage/border-patrol#readme",
+  "homepage": "https://github.com/seasav/border-patrol#readme",
   "devDependencies": {
     "@babel/core": "^7.28.4",
     "@babel/preset-env": "^7.28.3",

--- a/src/popup/components/Footer.tsx
+++ b/src/popup/components/Footer.tsx
@@ -44,7 +44,7 @@ export default function Footer(): React.ReactElement {
       />
 
       <Link
-        href='https://craigsavage.github.io/border-patrol/'
+        href='https://border-patrol.seasav.ca/'
         target='_blank'
         className='version'
         aria-label={translate('currentVersion', { version })}


### PR DESCRIPTION
# Overview:

Adds legal policy pages to the landing site and refreshes shared UI to surface them.

**Changes:**
- Add new `/privacy/` and `/terms/` pages with SEO metadata and content.
- Redesign footer to include policy links and updated layout.
- Improve changelog page layout and add content-specific styling in global CSS.
