### PR TITLE
Improve measurement mode with dynamic distance preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Measurement mode now shows a live distance preview as you move the mouse after selecting the first element, so you can quickly gauge distances without a second click. Clicking a second element locks the measurement in place as before.
+- Hovering over the second element now shows dashed corner guidelines extending to the viewport edges for alignment context. When the second element is wider than the first, left and right edge gap measurements are shown in addition to the vertical distance.
 
 ## [1.7.2] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Measurement mode now shows a live distance preview as you move the mouse after selecting the first element, so you can quickly gauge distances without a second click. Clicking a second element locks the measurement in place as before.
+
 ## [1.7.2] - 2026-04-09
 
 ### Changed

--- a/src/scripts/measurement.ts
+++ b/src/scripts/measurement.ts
@@ -354,10 +354,11 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
   }
 
   /** Draws the SVG connector and distance label(s) between the two selected elements. */
-  function drawConnector(): void {
+  function drawConnector(overrideSecond?: HTMLElement): void {
+    const second = overrideSecond ?? secondSelected;
     if (
       !firstSelected ||
-      !secondSelected ||
+      !second ||
       !connectorLine ||
       !distanceLabel ||
       !xDistanceLabel ||
@@ -366,7 +367,7 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
       return;
 
     const rectA = firstSelected.getBoundingClientRect();
-    const rectB = secondSelected.getBoundingClientRect();
+    const rectB = second.getBoundingClientRect();
     const { pointA: a, pointB: b, xGap, yGap } = getEdgeData(rectA, rectB);
 
     const svgNS = 'http://www.w3.org/2000/svg';
@@ -554,6 +555,16 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
     if (target === firstSelected || target === secondSelected) return;
 
     hoveredElement = target;
+
+    // After first selection, show a live preview of the measurement
+    if (firstSelected && !secondSelected && target !== firstSelected) {
+      if (secondHighlight) positionHighlight(secondHighlight, target, false);
+      if (secondBadge) positionBadge(secondBadge, target);
+      if (secondSizeLabel) positionSizeLabel(secondSizeLabel, target);
+      drawConnector(target);
+      return;
+    }
+
     if (hoverHighlight) {
       positionHighlight(hoverHighlight, target, false);
     }
@@ -563,6 +574,18 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
   function mouseOutHandler(): void {
     hoveredElement = null;
     if (hoverHighlight) hoverHighlight.style.display = 'none';
+
+    // Hide preview elements when mousing out without a confirmed second selection
+    if (firstSelected && !secondSelected) {
+      if (secondHighlight) secondHighlight.style.display = 'none';
+      if (secondBadge) secondBadge.style.display = 'none';
+      if (secondSizeLabel) secondSizeLabel.style.display = 'none';
+      if (connectorLine)
+        (connectorLine as unknown as HTMLElement).style.display = 'none';
+      if (distanceLabel) distanceLabel.style.display = 'none';
+      if (xDistanceLabel) xDistanceLabel.style.display = 'none';
+      if (yDistanceLabel) yDistanceLabel.style.display = 'none';
+    }
   }
 
   /**

--- a/src/scripts/measurement.ts
+++ b/src/scripts/measurement.ts
@@ -1,6 +1,15 @@
 import Logger from './utils/logger';
 import MEASUREMENT_STYLES from '../styles/components/measurement.shadow.scss';
 import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
+import { MeasurementLabelRefs } from 'types/scripts/measurement';
+import { getEdgeData, EDGE_EPSILON } from './utils/measurement-geometry';
+import {
+  drawGuidelines,
+  drawLShaped,
+  drawHEdgeMisalign,
+  drawVEdgeMisalign,
+  drawSingleAxis,
+} from './utils/measurement-svg';
 
 (function () {
   let isMeasurementModeEnabled = false;
@@ -33,11 +42,6 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
   const OUTLINE_COLOR = 'rgba(59, 130, 246, 0.8)';
   const SELECTED_COLOR = 'rgba(16, 185, 129, 0.15)';
   const SELECTED_OUTLINE = 'rgba(16, 185, 129, 0.8)';
-  const CONNECTOR_COLOR = '#ef4444';
-  const GUIDELINE_COLOR = 'rgba(148, 163, 184, 0.3)';
-  /** Minimum pixel difference before an edge misalignment is shown. */
-  const EDGE_EPSILON = 1;
-  const SVG_NS = 'http://www.w3.org/2000/svg';
 
   /**
    * Checks if an element belongs to the measurement UI itself.
@@ -300,273 +304,6 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
     label.style.display = 'block';
   }
 
-  /**
-   * Returns the nearest edge anchor points between two DOMRects along with
-   * the individual horizontal and vertical gap distances between them.
-   *
-   * @param a - The first element's bounding rect.
-   * @param b - The second element's bounding rect.
-   * @returns Edge anchor points on each rect and the x/y gap values.
-   */
-  function getEdgeData(
-    a: DOMRect,
-    b: DOMRect,
-  ): {
-    pointA: { x: number; y: number };
-    pointB: { x: number; y: number };
-    xGap: number;
-    yGap: number;
-  } {
-    // Horizontal component
-    let ax: number, bx: number, xGap: number;
-    if (a.right <= b.left) {
-      ax = a.right;
-      bx = b.left;
-      xGap = b.left - a.right;
-    } else if (b.right <= a.left) {
-      ax = a.left;
-      bx = b.right;
-      xGap = a.left - b.right;
-    } else {
-      const xMid = (Math.max(a.left, b.left) + Math.min(a.right, b.right)) / 2;
-      ax = xMid;
-      bx = xMid;
-      xGap = 0;
-    }
-
-    // Vertical component
-    let ay: number, by: number, yGap: number;
-    if (a.bottom <= b.top) {
-      ay = a.bottom;
-      by = b.top;
-      yGap = b.top - a.bottom;
-    } else if (b.bottom <= a.top) {
-      ay = a.top;
-      by = b.bottom;
-      yGap = a.top - b.bottom;
-    } else {
-      const yMid = (Math.max(a.top, b.top) + Math.min(a.bottom, b.bottom)) / 2;
-      ay = yMid;
-      by = yMid;
-      yGap = 0;
-    }
-
-    return {
-      pointA: { x: ax, y: ay },
-      pointB: { x: bx, y: by },
-      xGap,
-      yGap,
-    };
-  }
-
-  // ---------------------------------------------------------------------------
-  // SVG primitive helpers — append directly to connectorLine
-  // ---------------------------------------------------------------------------
-
-  /** Appends a dashed connector line between two points to the SVG overlay. */
-  function appendConnectorLine(
-    x1: number,
-    y1: number,
-    x2: number,
-    y2: number,
-  ): void {
-    if (!connectorLine) return;
-    const el = document.createElementNS(SVG_NS, 'line');
-    el.setAttribute('x1', String(x1));
-    el.setAttribute('y1', String(y1));
-    el.setAttribute('x2', String(x2));
-    el.setAttribute('y2', String(y2));
-    el.setAttribute('stroke', CONNECTOR_COLOR);
-    el.setAttribute('stroke-width', '2');
-    el.setAttribute('stroke-dasharray', '6 4');
-    connectorLine.appendChild(el);
-  }
-
-  /** Appends a filled circle to the SVG overlay. */
-  function appendConnectorDot(
-    cx: number,
-    cy: number,
-    r = 4,
-    opacity?: string,
-  ): void {
-    if (!connectorLine) return;
-    const el = document.createElementNS(SVG_NS, 'circle');
-    el.setAttribute('cx', String(cx));
-    el.setAttribute('cy', String(cy));
-    el.setAttribute('r', String(r));
-    el.setAttribute('fill', CONNECTOR_COLOR);
-    if (opacity !== undefined) el.setAttribute('opacity', opacity);
-    connectorLine.appendChild(el);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Connector branch functions — each handles one measurement layout
-  // ---------------------------------------------------------------------------
-
-  /** L-shaped connector for elements offset on both axes. */
-  function drawLShaped(
-    a: { x: number; y: number },
-    b: { x: number; y: number },
-    xGap: number,
-    yGap: number,
-  ): void {
-    const corner = { x: b.x, y: a.y };
-    appendConnectorLine(a.x, a.y, corner.x, corner.y);
-    appendConnectorLine(corner.x, corner.y, b.x, b.y);
-    appendConnectorDot(a.x, a.y);
-    appendConnectorDot(b.x, b.y);
-    appendConnectorDot(corner.x, corner.y, 3, '0.5');
-
-    xDistanceLabel!.textContent = `${Math.round(xGap)}px`;
-    xDistanceLabel!.style.position = 'fixed';
-    xDistanceLabel!.style.left = `${(a.x + corner.x) / 2}px`;
-    xDistanceLabel!.style.top = `${a.y}px`;
-    xDistanceLabel!.style.display = 'block';
-
-    yDistanceLabel!.textContent = `${Math.round(yGap)}px`;
-    yDistanceLabel!.style.position = 'fixed';
-    yDistanceLabel!.style.left = `${corner.x}px`;
-    yDistanceLabel!.style.top = `${(corner.y + b.y) / 2}px`;
-    yDistanceLabel!.style.display = 'block';
-  }
-
-  /**
-   * Horizontal edge-misalignment layout: elements are vertically separated with
-   * horizontal overlap but misaligned left/right edges. Shows the y-gap plus
-   * left and/or right edge differences.
-   */
-  function drawHEdgeMisalign(
-    rectA: DOMRect,
-    rectB: DOMRect,
-    a: { x: number; y: number },
-    b: { x: number; y: number },
-    yGap: number,
-  ): void {
-    const leftEdgeDiff = Math.abs(rectA.left - rectB.left);
-    const rightEdgeDiff = Math.abs(rectA.right - rectB.right);
-    const yBetween = (a.y + b.y) / 2;
-    const rectACenterY = rectA.top + rectA.height / 2;
-    const rectBCenterY = rectB.top + rectB.height / 2;
-    const leftGapY = rectA.left > rectB.left ? rectACenterY : rectBCenterY;
-    const rightGapY = rectA.right < rectB.right ? rectACenterY : rectBCenterY;
-
-    appendConnectorLine(a.x, a.y, a.x, b.y);
-    appendConnectorDot(a.x, a.y);
-    appendConnectorDot(a.x, b.y);
-
-    yDistanceLabel!.textContent = `${Math.round(yGap)}px`;
-    yDistanceLabel!.style.position = 'fixed';
-    yDistanceLabel!.style.left = `${a.x}px`;
-    yDistanceLabel!.style.top = `${yBetween}px`;
-    yDistanceLabel!.style.display = 'block';
-
-    if (leftEdgeDiff > EDGE_EPSILON) {
-      const leftFrom = Math.min(rectA.left, rectB.left);
-      const leftTo = Math.max(rectA.left, rectB.left);
-      appendConnectorLine(leftFrom, leftGapY, leftTo, leftGapY);
-      appendConnectorDot(leftFrom, leftGapY);
-      appendConnectorDot(leftTo, leftGapY);
-      xDistanceLabel!.textContent = `${Math.round(leftEdgeDiff)}px`;
-      xDistanceLabel!.style.position = 'fixed';
-      xDistanceLabel!.style.left = `${(leftFrom + leftTo) / 2}px`;
-      xDistanceLabel!.style.top = `${leftGapY}px`;
-      xDistanceLabel!.style.display = 'block';
-    }
-
-    if (rightEdgeDiff > EDGE_EPSILON) {
-      const rightFrom = Math.min(rectA.right, rectB.right);
-      const rightTo = Math.max(rectA.right, rectB.right);
-      appendConnectorLine(rightFrom, rightGapY, rightTo, rightGapY);
-      appendConnectorDot(rightFrom, rightGapY);
-      appendConnectorDot(rightTo, rightGapY);
-      distanceLabel!.textContent = `${Math.round(rightEdgeDiff)}px`;
-      distanceLabel!.style.position = 'fixed';
-      distanceLabel!.style.left = `${(rightFrom + rightTo) / 2}px`;
-      distanceLabel!.style.top = `${rightGapY}px`;
-      distanceLabel!.style.display = 'block';
-    }
-  }
-
-  /**
-   * Vertical edge-misalignment layout: elements are horizontally separated with
-   * vertical overlap but misaligned top/bottom edges. Shows the x-gap plus
-   * top and/or bottom edge differences.
-   */
-  function drawVEdgeMisalign(
-    rectA: DOMRect,
-    rectB: DOMRect,
-    a: { x: number; y: number },
-    b: { x: number; y: number },
-    xGap: number,
-  ): void {
-    const topEdgeDiff = Math.abs(rectA.top - rectB.top);
-    const bottomEdgeDiff = Math.abs(rectA.bottom - rectB.bottom);
-    const xBetween = (a.x + b.x) / 2;
-    const rectACenterX = rectA.left + rectA.width / 2;
-    const rectBCenterX = rectB.left + rectB.width / 2;
-    const topGapX = rectA.top > rectB.top ? rectACenterX : rectBCenterX;
-    const bottomGapX =
-      rectA.bottom < rectB.bottom ? rectACenterX : rectBCenterX;
-
-    appendConnectorLine(a.x, a.y, b.x, b.y);
-    appendConnectorDot(a.x, a.y);
-    appendConnectorDot(b.x, b.y);
-
-    distanceLabel!.textContent = `${Math.round(xGap)}px`;
-    distanceLabel!.style.position = 'fixed';
-    distanceLabel!.style.left = `${xBetween}px`;
-    distanceLabel!.style.top = `${a.y}px`;
-    distanceLabel!.style.display = 'block';
-
-    if (topEdgeDiff > EDGE_EPSILON) {
-      const topFrom = Math.min(rectA.top, rectB.top);
-      const topTo = Math.max(rectA.top, rectB.top);
-      appendConnectorLine(topGapX, topFrom, topGapX, topTo);
-      appendConnectorDot(topGapX, topFrom);
-      appendConnectorDot(topGapX, topTo);
-      xDistanceLabel!.textContent = `${Math.round(topEdgeDiff)}px`;
-      xDistanceLabel!.style.position = 'fixed';
-      xDistanceLabel!.style.left = `${topGapX}px`;
-      xDistanceLabel!.style.top = `${(topFrom + topTo) / 2}px`;
-      xDistanceLabel!.style.display = 'block';
-    }
-
-    if (bottomEdgeDiff > EDGE_EPSILON) {
-      const bottomFrom = Math.min(rectA.bottom, rectB.bottom);
-      const bottomTo = Math.max(rectA.bottom, rectB.bottom);
-      appendConnectorLine(bottomGapX, bottomFrom, bottomGapX, bottomTo);
-      appendConnectorDot(bottomGapX, bottomFrom);
-      appendConnectorDot(bottomGapX, bottomTo);
-      yDistanceLabel!.textContent = `${Math.round(bottomEdgeDiff)}px`;
-      yDistanceLabel!.style.position = 'fixed';
-      yDistanceLabel!.style.left = `${bottomGapX}px`;
-      yDistanceLabel!.style.top = `${(bottomFrom + bottomTo) / 2}px`;
-      yDistanceLabel!.style.display = 'block';
-    }
-  }
-
-  /** Single dashed line with one distance label for pure x or y separation. */
-  function drawSingleAxis(
-    a: { x: number; y: number },
-    b: { x: number; y: number },
-    xGap: number,
-    yGap: number,
-  ): void {
-    appendConnectorLine(a.x, a.y, b.x, b.y);
-    appendConnectorDot(a.x, a.y);
-    appendConnectorDot(b.x, b.y);
-    const dist = xGap > 0 ? Math.round(xGap) : Math.round(yGap);
-    distanceLabel!.textContent = `${dist}px`;
-    distanceLabel!.style.position = 'fixed';
-    distanceLabel!.style.left = `${(a.x + b.x) / 2}px`;
-    distanceLabel!.style.top = `${(a.y + b.y) / 2}px`;
-    distanceLabel!.style.display = 'block';
-  }
-
-  // ---------------------------------------------------------------------------
-  // Main connector dispatcher
-  // ---------------------------------------------------------------------------
-
   /** Draws the SVG connector and distance label(s) between the two selected elements. */
   function drawConnector(overrideSecond?: HTMLElement): void {
     const second = overrideSecond ?? secondSelected;
@@ -584,6 +321,11 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
     const rectB = second.getBoundingClientRect();
     const { pointA: a, pointB: b, xGap, yGap } = getEdgeData(rectA, rectB);
     const svgEl = connectorLine as unknown as HTMLElement;
+    const labels: MeasurementLabelRefs = {
+      distanceLabel,
+      xDistanceLabel,
+      yDistanceLabel,
+    };
 
     distanceLabel.style.display = 'none';
     xDistanceLabel.style.display = 'none';
@@ -617,64 +359,28 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
       connectorLine.removeChild(connectorLine.firstChild);
     }
 
-    drawGuidelines(rectA);
-    drawGuidelines(rectB);
+    drawGuidelines(connectorLine, rectA);
+    drawGuidelines(connectorLine, rectB);
 
     if (xGap > 0 && yGap > 0) {
-      drawLShaped(a, b, xGap, yGap);
+      drawLShaped(connectorLine, labels, a, b, xGap, yGap);
     } else if (
       xGap === 0 &&
       yGap > 0 &&
       (Math.abs(rectA.left - rectB.left) > EDGE_EPSILON ||
         Math.abs(rectA.right - rectB.right) > EDGE_EPSILON)
     ) {
-      drawHEdgeMisalign(rectA, rectB, a, b, yGap);
+      drawHEdgeMisalign(connectorLine, labels, rectA, rectB, a, b, yGap);
     } else if (
       yGap === 0 &&
       xGap > 0 &&
       (Math.abs(rectA.top - rectB.top) > EDGE_EPSILON ||
         Math.abs(rectA.bottom - rectB.bottom) > EDGE_EPSILON)
     ) {
-      drawVEdgeMisalign(rectA, rectB, a, b, xGap);
+      drawVEdgeMisalign(connectorLine, labels, rectA, rectB, a, b, xGap);
     } else {
-      drawSingleAxis(a, b, xGap, yGap);
+      drawSingleAxis(connectorLine, labels, a, b, xGap, yGap);
     }
-  }
-
-  /**
-   * Draws thin dashed guideline extensions from each corner of the given rect
-   * to the viewport edges. Called for both elements so connector lines always
-   * originate from a visible guideline.
-   *
-   * @param rect - The bounding rect of an element to draw guidelines for.
-   */
-  function drawGuidelines(rect: DOMRect): void {
-    if (!connectorLine) return;
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-
-    const segments: [number, number, number, number][] = [
-      [0, rect.top, rect.left, rect.top],
-      [rect.left, 0, rect.left, rect.top],
-      [rect.right, rect.top, vw, rect.top],
-      [rect.right, 0, rect.right, rect.top],
-      [0, rect.bottom, rect.left, rect.bottom],
-      [rect.left, rect.bottom, rect.left, vh],
-      [rect.right, rect.bottom, vw, rect.bottom],
-      [rect.right, rect.bottom, rect.right, vh],
-    ];
-
-    segments.forEach(([x1, y1, x2, y2]) => {
-      const line = document.createElementNS(SVG_NS, 'line');
-      line.setAttribute('x1', String(x1));
-      line.setAttribute('y1', String(y1));
-      line.setAttribute('x2', String(x2));
-      line.setAttribute('y2', String(y2));
-      line.setAttribute('stroke', GUIDELINE_COLOR);
-      line.setAttribute('stroke-width', '1');
-      line.setAttribute('stroke-dasharray', '4 4');
-      connectorLine!.appendChild(line);
-    });
   }
 
   /**

--- a/src/scripts/measurement.ts
+++ b/src/scripts/measurement.ts
@@ -409,7 +409,8 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
       connectorLine.removeChild(connectorLine.firstChild);
     }
 
-    // Draw corner guidelines for the second element (behind connector lines)
+    // Draw corner guidelines for both elements (behind connector lines)
+    drawGuidelines(rectA);
     drawGuidelines(rectB);
 
     if (xGap > 0 && yGap > 0) {
@@ -553,6 +554,88 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
         distanceLabel.style.top = `${rightGapY}px`;
         distanceLabel.style.display = 'block';
       }
+    } else if (
+      yGap === 0 &&
+      xGap > 0 &&
+      (Math.abs(rectA.top - rectB.top) > 1 ||
+        Math.abs(rectA.bottom - rectB.bottom) > 1)
+    ) {
+      // Vertical both-edges case: elements overlap on y-axis but have misaligned
+      // top/bottom edges. Show top/bottom edge gaps alongside the x-gap.
+      const topEdgeDiff = Math.abs(rectA.top - rectB.top);
+      const bottomEdgeDiff = Math.abs(rectA.bottom - rectB.bottom);
+      const xBetween = (a.x + b.x) / 2;
+      const rectACenterX = rectA.left + rectA.width / 2;
+      const rectBCenterX = rectB.left + rectB.width / 2;
+      // Anchor each edge gap line to the x-centre of the inset element
+      const topGapX = rectA.top > rectB.top ? rectACenterX : rectBCenterX;
+      const bottomGapX =
+        rectA.bottom < rectB.bottom ? rectACenterX : rectBCenterX;
+
+      const drawVSeg = (
+        x1: number,
+        y1: number,
+        x2: number,
+        y2: number,
+      ): void => {
+        const seg = document.createElementNS(svgNS, 'line');
+        seg.setAttribute('x1', String(x1));
+        seg.setAttribute('y1', String(y1));
+        seg.setAttribute('x2', String(x2));
+        seg.setAttribute('y2', String(y2));
+        seg.setAttribute('stroke', CONNECTOR_COLOR);
+        seg.setAttribute('stroke-width', '2');
+        seg.setAttribute('stroke-dasharray', '6 4');
+        connectorLine!.appendChild(seg);
+      };
+
+      const drawVCircle = (cx: number, cy: number): void => {
+        const circle = document.createElementNS(svgNS, 'circle');
+        circle.setAttribute('cx', String(cx));
+        circle.setAttribute('cy', String(cy));
+        circle.setAttribute('r', '4');
+        circle.setAttribute('fill', CONNECTOR_COLOR);
+        connectorLine!.appendChild(circle);
+      };
+
+      // Horizontal x-gap line at the vertical midpoint of the overlap
+      drawVSeg(a.x, a.y, b.x, b.y);
+      drawVCircle(a.x, a.y);
+      drawVCircle(b.x, b.y);
+
+      distanceLabel.textContent = `${Math.round(xGap)}px`;
+      distanceLabel.style.position = 'fixed';
+      distanceLabel.style.left = `${xBetween}px`;
+      distanceLabel.style.top = `${a.y}px`;
+      distanceLabel.style.display = 'block';
+
+      // Top edge gap — anchored to the x-centre of the inset element
+      if (topEdgeDiff > 1) {
+        const topFrom = Math.min(rectA.top, rectB.top);
+        const topTo = Math.max(rectA.top, rectB.top);
+        drawVSeg(topGapX, topFrom, topGapX, topTo);
+        drawVCircle(topGapX, topFrom);
+        drawVCircle(topGapX, topTo);
+        xDistanceLabel.textContent = `${Math.round(topEdgeDiff)}px`;
+        xDistanceLabel.style.position = 'fixed';
+        xDistanceLabel.style.left = `${topGapX}px`;
+        xDistanceLabel.style.top = `${(topFrom + topTo) / 2}px`;
+        xDistanceLabel.style.display = 'block';
+      }
+
+      // Bottom edge gap — anchored to the x-centre of the inset element
+      if (bottomEdgeDiff > 1) {
+        const bottomFrom = Math.min(rectA.bottom, rectB.bottom);
+        const bottomTo = Math.max(rectA.bottom, rectB.bottom);
+        drawVSeg(bottomGapX, bottomFrom, bottomGapX, bottomTo);
+        drawVCircle(bottomGapX, bottomFrom);
+        drawVCircle(bottomGapX, bottomTo);
+        yDistanceLabel.textContent = `${Math.round(bottomEdgeDiff)}px`;
+        yDistanceLabel.style.position = 'fixed';
+        yDistanceLabel.style.left = `${bottomGapX}px`;
+        yDistanceLabel.style.top = `${(bottomFrom + bottomTo) / 2}px`;
+        yDistanceLabel.style.display = 'block';
+      }
     } else {
       // Single-axis: one straight line with one label
       const line = document.createElementNS(svgNS, 'line');
@@ -651,6 +734,12 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
     }
     if (firstSelected && secondSelected) {
       drawConnector();
+    } else if (firstSelected && !secondSelected && hoveredElement) {
+      if (secondHighlight)
+        positionHighlight(secondHighlight, hoveredElement, false);
+      if (secondBadge) positionBadge(secondBadge, hoveredElement);
+      if (secondSizeLabel) positionSizeLabel(secondSizeLabel, hoveredElement);
+      drawConnector(hoveredElement);
     }
   }
 

--- a/src/scripts/measurement.ts
+++ b/src/scripts/measurement.ts
@@ -482,6 +482,12 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
       const leftEdgeDiff = Math.abs(rectA.left - rectB.left);
       const rightEdgeDiff = Math.abs(rectA.right - rectB.right);
       const yBetween = (a.y + b.y) / 2;
+      const rectACenterY = rectA.top + rectA.height / 2;
+      const rectBCenterY = rectB.top + rectB.height / 2;
+      // For each side, anchor the gap line to the centre of whichever element
+      // is inset (the "smaller" side) so the line runs through that element.
+      const leftGapY = rectA.left > rectB.left ? rectACenterY : rectBCenterY;
+      const rightGapY = rectA.right < rectB.right ? rectACenterY : rectBCenterY;
 
       const drawEdgeSeg = (
         x1: number,
@@ -520,31 +526,31 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
       yDistanceLabel.style.top = `${yBetween}px`;
       yDistanceLabel.style.display = 'block';
 
-      // Left edge gap
+      // Left edge gap — anchored to the centre of the inset element
       if (leftEdgeDiff > 1) {
         const leftFrom = Math.min(rectA.left, rectB.left);
         const leftTo = Math.max(rectA.left, rectB.left);
-        drawEdgeSeg(leftFrom, yBetween, leftTo, yBetween);
-        drawEdgeCircle(leftFrom, yBetween);
-        drawEdgeCircle(leftTo, yBetween);
+        drawEdgeSeg(leftFrom, leftGapY, leftTo, leftGapY);
+        drawEdgeCircle(leftFrom, leftGapY);
+        drawEdgeCircle(leftTo, leftGapY);
         xDistanceLabel.textContent = `${Math.round(leftEdgeDiff)}px`;
         xDistanceLabel.style.position = 'fixed';
         xDistanceLabel.style.left = `${(leftFrom + leftTo) / 2}px`;
-        xDistanceLabel.style.top = `${yBetween}px`;
+        xDistanceLabel.style.top = `${leftGapY}px`;
         xDistanceLabel.style.display = 'block';
       }
 
-      // Right edge gap
+      // Right edge gap — anchored to the centre of the inset element
       if (rightEdgeDiff > 1) {
         const rightFrom = Math.min(rectA.right, rectB.right);
         const rightTo = Math.max(rectA.right, rectB.right);
-        drawEdgeSeg(rightFrom, yBetween, rightTo, yBetween);
-        drawEdgeCircle(rightFrom, yBetween);
-        drawEdgeCircle(rightTo, yBetween);
+        drawEdgeSeg(rightFrom, rightGapY, rightTo, rightGapY);
+        drawEdgeCircle(rightFrom, rightGapY);
+        drawEdgeCircle(rightTo, rightGapY);
         distanceLabel.textContent = `${Math.round(rightEdgeDiff)}px`;
         distanceLabel.style.position = 'fixed';
         distanceLabel.style.left = `${(rightFrom + rightTo) / 2}px`;
-        distanceLabel.style.top = `${yBetween}px`;
+        distanceLabel.style.top = `${rightGapY}px`;
         distanceLabel.style.display = 'block';
       }
     } else {
@@ -614,6 +620,7 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
       line.setAttribute('y2', String(y2));
       line.setAttribute('stroke', GUIDELINE_COLOR);
       line.setAttribute('stroke-width', '1');
+      line.setAttribute('stroke-dasharray', '4 4');
       connectorLine!.appendChild(line);
     });
   }

--- a/src/scripts/measurement.ts
+++ b/src/scripts/measurement.ts
@@ -32,6 +32,7 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
   const SELECTED_COLOR = 'rgba(16, 185, 129, 0.15)';
   const SELECTED_OUTLINE = 'rgba(16, 185, 129, 0.8)';
   const CONNECTOR_COLOR = '#ef4444';
+  const GUIDELINE_COLOR = 'rgba(148, 163, 184, 0.3)';
 
   /**
    * Checks if an element belongs to the measurement UI itself.
@@ -408,6 +409,9 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
       connectorLine.removeChild(connectorLine.firstChild);
     }
 
+    // Draw corner guidelines for the second element (behind connector lines)
+    drawGuidelines(rectB);
+
     if (xGap > 0 && yGap > 0) {
       // L-shaped connector: horizontal segment then vertical segment
       // Corner sits at (b.x, a.y) — horizontal from A, then vertical to B
@@ -467,6 +471,82 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
       yDistanceLabel.style.left = `${corner.x}px`;
       yDistanceLabel.style.top = `${(corner.y + b.y) / 2}px`;
       yDistanceLabel.style.display = 'block';
+    } else if (
+      xGap === 0 &&
+      yGap > 0 &&
+      (Math.abs(rectA.left - rectB.left) > 1 ||
+        Math.abs(rectA.right - rectB.right) > 1)
+    ) {
+      // Both-edges case: elements overlap on x-axis but have misaligned edges.
+      // Show left/right edge gaps and the y-gap separately.
+      const leftEdgeDiff = Math.abs(rectA.left - rectB.left);
+      const rightEdgeDiff = Math.abs(rectA.right - rectB.right);
+      const yBetween = (a.y + b.y) / 2;
+
+      const drawEdgeSeg = (
+        x1: number,
+        y1: number,
+        x2: number,
+        y2: number,
+      ): void => {
+        const seg = document.createElementNS(svgNS, 'line');
+        seg.setAttribute('x1', String(x1));
+        seg.setAttribute('y1', String(y1));
+        seg.setAttribute('x2', String(x2));
+        seg.setAttribute('y2', String(y2));
+        seg.setAttribute('stroke', CONNECTOR_COLOR);
+        seg.setAttribute('stroke-width', '2');
+        seg.setAttribute('stroke-dasharray', '6 4');
+        connectorLine!.appendChild(seg);
+      };
+
+      const drawEdgeCircle = (cx: number, cy: number): void => {
+        const circle = document.createElementNS(svgNS, 'circle');
+        circle.setAttribute('cx', String(cx));
+        circle.setAttribute('cy', String(cy));
+        circle.setAttribute('r', '4');
+        circle.setAttribute('fill', CONNECTOR_COLOR);
+        connectorLine!.appendChild(circle);
+      };
+
+      // Vertical y-gap line at the horizontal midpoint of the overlap
+      drawEdgeSeg(a.x, a.y, a.x, b.y);
+      drawEdgeCircle(a.x, a.y);
+      drawEdgeCircle(a.x, b.y);
+
+      yDistanceLabel.textContent = `${Math.round(yGap)}px`;
+      yDistanceLabel.style.position = 'fixed';
+      yDistanceLabel.style.left = `${a.x}px`;
+      yDistanceLabel.style.top = `${yBetween}px`;
+      yDistanceLabel.style.display = 'block';
+
+      // Left edge gap
+      if (leftEdgeDiff > 1) {
+        const leftFrom = Math.min(rectA.left, rectB.left);
+        const leftTo = Math.max(rectA.left, rectB.left);
+        drawEdgeSeg(leftFrom, yBetween, leftTo, yBetween);
+        drawEdgeCircle(leftFrom, yBetween);
+        drawEdgeCircle(leftTo, yBetween);
+        xDistanceLabel.textContent = `${Math.round(leftEdgeDiff)}px`;
+        xDistanceLabel.style.position = 'fixed';
+        xDistanceLabel.style.left = `${(leftFrom + leftTo) / 2}px`;
+        xDistanceLabel.style.top = `${yBetween}px`;
+        xDistanceLabel.style.display = 'block';
+      }
+
+      // Right edge gap
+      if (rightEdgeDiff > 1) {
+        const rightFrom = Math.min(rectA.right, rectB.right);
+        const rightTo = Math.max(rectA.right, rectB.right);
+        drawEdgeSeg(rightFrom, yBetween, rightTo, yBetween);
+        drawEdgeCircle(rightFrom, yBetween);
+        drawEdgeCircle(rightTo, yBetween);
+        distanceLabel.textContent = `${Math.round(rightEdgeDiff)}px`;
+        distanceLabel.style.position = 'fixed';
+        distanceLabel.style.left = `${(rightFrom + rightTo) / 2}px`;
+        distanceLabel.style.top = `${yBetween}px`;
+        distanceLabel.style.display = 'block';
+      }
     } else {
       // Single-axis: one straight line with one label
       const line = document.createElementNS(svgNS, 'line');
@@ -495,6 +575,47 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
       distanceLabel.style.top = `${(a.y + b.y) / 2}px`;
       distanceLabel.style.display = 'block';
     }
+  }
+
+  /**
+   * Draws thin guideline extensions from each corner of the given rect to the
+   * viewport edges. Called as part of drawConnector so guidelines appear behind
+   * the connector lines in the SVG paint order.
+   *
+   * @param rect - The bounding rect of the second (hovered or locked) element.
+   */
+  function drawGuidelines(rect: DOMRect): void {
+    if (!connectorLine) return;
+    const svgNS = 'http://www.w3.org/2000/svg';
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    // 8 segments: from each of the 4 corners, one horizontal + one vertical
+    const segments: [number, number, number, number][] = [
+      // Top-left corner
+      [0, rect.top, rect.left, rect.top], // left to viewport left edge
+      [rect.left, 0, rect.left, rect.top], // up to viewport top edge
+      // Top-right corner
+      [rect.right, rect.top, vw, rect.top], // right to viewport right edge
+      [rect.right, 0, rect.right, rect.top], // up to viewport top edge
+      // Bottom-left corner
+      [0, rect.bottom, rect.left, rect.bottom], // left to viewport left edge
+      [rect.left, rect.bottom, rect.left, vh], // down to viewport bottom edge
+      // Bottom-right corner
+      [rect.right, rect.bottom, vw, rect.bottom], // right to viewport right edge
+      [rect.right, rect.bottom, rect.right, vh], // down to viewport bottom edge
+    ];
+
+    segments.forEach(([x1, y1, x2, y2]) => {
+      const line = document.createElementNS(svgNS, 'line');
+      line.setAttribute('x1', String(x1));
+      line.setAttribute('y1', String(y1));
+      line.setAttribute('x2', String(x2));
+      line.setAttribute('y2', String(y2));
+      line.setAttribute('stroke', GUIDELINE_COLOR);
+      line.setAttribute('stroke-width', '1');
+      connectorLine!.appendChild(line);
+    });
   }
 
   /**

--- a/src/scripts/measurement.ts
+++ b/src/scripts/measurement.ts
@@ -13,6 +13,8 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
   let hoveredElement: HTMLElement | null = null;
   let firstSelected: HTMLElement | null = null;
   let secondSelected: HTMLElement | null = null;
+  let lastPreviewTarget: HTMLElement | null = null;
+  let previewRafId: number | null = null;
 
   // Shadow DOM elements for selection highlights and connector
   let hoverHighlight: HTMLElement | null = null;
@@ -33,6 +35,9 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
   const SELECTED_OUTLINE = 'rgba(16, 185, 129, 0.8)';
   const CONNECTOR_COLOR = '#ef4444';
   const GUIDELINE_COLOR = 'rgba(148, 163, 184, 0.3)';
+  /** Minimum pixel difference before an edge misalignment is shown. */
+  const EDGE_EPSILON = 1;
+  const SVG_NS = 'http://www.w3.org/2000/svg';
 
   /**
    * Checks if an element belongs to the measurement UI itself.
@@ -354,6 +359,214 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
     };
   }
 
+  // ---------------------------------------------------------------------------
+  // SVG primitive helpers — append directly to connectorLine
+  // ---------------------------------------------------------------------------
+
+  /** Appends a dashed connector line between two points to the SVG overlay. */
+  function appendConnectorLine(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+  ): void {
+    if (!connectorLine) return;
+    const el = document.createElementNS(SVG_NS, 'line');
+    el.setAttribute('x1', String(x1));
+    el.setAttribute('y1', String(y1));
+    el.setAttribute('x2', String(x2));
+    el.setAttribute('y2', String(y2));
+    el.setAttribute('stroke', CONNECTOR_COLOR);
+    el.setAttribute('stroke-width', '2');
+    el.setAttribute('stroke-dasharray', '6 4');
+    connectorLine.appendChild(el);
+  }
+
+  /** Appends a filled circle to the SVG overlay. */
+  function appendConnectorDot(
+    cx: number,
+    cy: number,
+    r = 4,
+    opacity?: string,
+  ): void {
+    if (!connectorLine) return;
+    const el = document.createElementNS(SVG_NS, 'circle');
+    el.setAttribute('cx', String(cx));
+    el.setAttribute('cy', String(cy));
+    el.setAttribute('r', String(r));
+    el.setAttribute('fill', CONNECTOR_COLOR);
+    if (opacity !== undefined) el.setAttribute('opacity', opacity);
+    connectorLine.appendChild(el);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connector branch functions — each handles one measurement layout
+  // ---------------------------------------------------------------------------
+
+  /** L-shaped connector for elements offset on both axes. */
+  function drawLShaped(
+    a: { x: number; y: number },
+    b: { x: number; y: number },
+    xGap: number,
+    yGap: number,
+  ): void {
+    const corner = { x: b.x, y: a.y };
+    appendConnectorLine(a.x, a.y, corner.x, corner.y);
+    appendConnectorLine(corner.x, corner.y, b.x, b.y);
+    appendConnectorDot(a.x, a.y);
+    appendConnectorDot(b.x, b.y);
+    appendConnectorDot(corner.x, corner.y, 3, '0.5');
+
+    xDistanceLabel!.textContent = `${Math.round(xGap)}px`;
+    xDistanceLabel!.style.position = 'fixed';
+    xDistanceLabel!.style.left = `${(a.x + corner.x) / 2}px`;
+    xDistanceLabel!.style.top = `${a.y}px`;
+    xDistanceLabel!.style.display = 'block';
+
+    yDistanceLabel!.textContent = `${Math.round(yGap)}px`;
+    yDistanceLabel!.style.position = 'fixed';
+    yDistanceLabel!.style.left = `${corner.x}px`;
+    yDistanceLabel!.style.top = `${(corner.y + b.y) / 2}px`;
+    yDistanceLabel!.style.display = 'block';
+  }
+
+  /**
+   * Horizontal edge-misalignment layout: elements are vertically separated with
+   * horizontal overlap but misaligned left/right edges. Shows the y-gap plus
+   * left and/or right edge differences.
+   */
+  function drawHEdgeMisalign(
+    rectA: DOMRect,
+    rectB: DOMRect,
+    a: { x: number; y: number },
+    b: { x: number; y: number },
+    yGap: number,
+  ): void {
+    const leftEdgeDiff = Math.abs(rectA.left - rectB.left);
+    const rightEdgeDiff = Math.abs(rectA.right - rectB.right);
+    const yBetween = (a.y + b.y) / 2;
+    const rectACenterY = rectA.top + rectA.height / 2;
+    const rectBCenterY = rectB.top + rectB.height / 2;
+    const leftGapY = rectA.left > rectB.left ? rectACenterY : rectBCenterY;
+    const rightGapY = rectA.right < rectB.right ? rectACenterY : rectBCenterY;
+
+    appendConnectorLine(a.x, a.y, a.x, b.y);
+    appendConnectorDot(a.x, a.y);
+    appendConnectorDot(a.x, b.y);
+
+    yDistanceLabel!.textContent = `${Math.round(yGap)}px`;
+    yDistanceLabel!.style.position = 'fixed';
+    yDistanceLabel!.style.left = `${a.x}px`;
+    yDistanceLabel!.style.top = `${yBetween}px`;
+    yDistanceLabel!.style.display = 'block';
+
+    if (leftEdgeDiff > EDGE_EPSILON) {
+      const leftFrom = Math.min(rectA.left, rectB.left);
+      const leftTo = Math.max(rectA.left, rectB.left);
+      appendConnectorLine(leftFrom, leftGapY, leftTo, leftGapY);
+      appendConnectorDot(leftFrom, leftGapY);
+      appendConnectorDot(leftTo, leftGapY);
+      xDistanceLabel!.textContent = `${Math.round(leftEdgeDiff)}px`;
+      xDistanceLabel!.style.position = 'fixed';
+      xDistanceLabel!.style.left = `${(leftFrom + leftTo) / 2}px`;
+      xDistanceLabel!.style.top = `${leftGapY}px`;
+      xDistanceLabel!.style.display = 'block';
+    }
+
+    if (rightEdgeDiff > EDGE_EPSILON) {
+      const rightFrom = Math.min(rectA.right, rectB.right);
+      const rightTo = Math.max(rectA.right, rectB.right);
+      appendConnectorLine(rightFrom, rightGapY, rightTo, rightGapY);
+      appendConnectorDot(rightFrom, rightGapY);
+      appendConnectorDot(rightTo, rightGapY);
+      distanceLabel!.textContent = `${Math.round(rightEdgeDiff)}px`;
+      distanceLabel!.style.position = 'fixed';
+      distanceLabel!.style.left = `${(rightFrom + rightTo) / 2}px`;
+      distanceLabel!.style.top = `${rightGapY}px`;
+      distanceLabel!.style.display = 'block';
+    }
+  }
+
+  /**
+   * Vertical edge-misalignment layout: elements are horizontally separated with
+   * vertical overlap but misaligned top/bottom edges. Shows the x-gap plus
+   * top and/or bottom edge differences.
+   */
+  function drawVEdgeMisalign(
+    rectA: DOMRect,
+    rectB: DOMRect,
+    a: { x: number; y: number },
+    b: { x: number; y: number },
+    xGap: number,
+  ): void {
+    const topEdgeDiff = Math.abs(rectA.top - rectB.top);
+    const bottomEdgeDiff = Math.abs(rectA.bottom - rectB.bottom);
+    const xBetween = (a.x + b.x) / 2;
+    const rectACenterX = rectA.left + rectA.width / 2;
+    const rectBCenterX = rectB.left + rectB.width / 2;
+    const topGapX = rectA.top > rectB.top ? rectACenterX : rectBCenterX;
+    const bottomGapX =
+      rectA.bottom < rectB.bottom ? rectACenterX : rectBCenterX;
+
+    appendConnectorLine(a.x, a.y, b.x, b.y);
+    appendConnectorDot(a.x, a.y);
+    appendConnectorDot(b.x, b.y);
+
+    distanceLabel!.textContent = `${Math.round(xGap)}px`;
+    distanceLabel!.style.position = 'fixed';
+    distanceLabel!.style.left = `${xBetween}px`;
+    distanceLabel!.style.top = `${a.y}px`;
+    distanceLabel!.style.display = 'block';
+
+    if (topEdgeDiff > EDGE_EPSILON) {
+      const topFrom = Math.min(rectA.top, rectB.top);
+      const topTo = Math.max(rectA.top, rectB.top);
+      appendConnectorLine(topGapX, topFrom, topGapX, topTo);
+      appendConnectorDot(topGapX, topFrom);
+      appendConnectorDot(topGapX, topTo);
+      xDistanceLabel!.textContent = `${Math.round(topEdgeDiff)}px`;
+      xDistanceLabel!.style.position = 'fixed';
+      xDistanceLabel!.style.left = `${topGapX}px`;
+      xDistanceLabel!.style.top = `${(topFrom + topTo) / 2}px`;
+      xDistanceLabel!.style.display = 'block';
+    }
+
+    if (bottomEdgeDiff > EDGE_EPSILON) {
+      const bottomFrom = Math.min(rectA.bottom, rectB.bottom);
+      const bottomTo = Math.max(rectA.bottom, rectB.bottom);
+      appendConnectorLine(bottomGapX, bottomFrom, bottomGapX, bottomTo);
+      appendConnectorDot(bottomGapX, bottomFrom);
+      appendConnectorDot(bottomGapX, bottomTo);
+      yDistanceLabel!.textContent = `${Math.round(bottomEdgeDiff)}px`;
+      yDistanceLabel!.style.position = 'fixed';
+      yDistanceLabel!.style.left = `${bottomGapX}px`;
+      yDistanceLabel!.style.top = `${(bottomFrom + bottomTo) / 2}px`;
+      yDistanceLabel!.style.display = 'block';
+    }
+  }
+
+  /** Single dashed line with one distance label for pure x or y separation. */
+  function drawSingleAxis(
+    a: { x: number; y: number },
+    b: { x: number; y: number },
+    xGap: number,
+    yGap: number,
+  ): void {
+    appendConnectorLine(a.x, a.y, b.x, b.y);
+    appendConnectorDot(a.x, a.y);
+    appendConnectorDot(b.x, b.y);
+    const dist = xGap > 0 ? Math.round(xGap) : Math.round(yGap);
+    distanceLabel!.textContent = `${dist}px`;
+    distanceLabel!.style.position = 'fixed';
+    distanceLabel!.style.left = `${(a.x + b.x) / 2}px`;
+    distanceLabel!.style.top = `${(a.y + b.y) / 2}px`;
+    distanceLabel!.style.display = 'block';
+  }
+
+  // ---------------------------------------------------------------------------
+  // Main connector dispatcher
+  // ---------------------------------------------------------------------------
+
   /** Draws the SVG connector and distance label(s) between the two selected elements. */
   function drawConnector(overrideSecond?: HTMLElement): void {
     const second = overrideSecond ?? secondSelected;
@@ -370,11 +583,8 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
     const rectA = firstSelected.getBoundingClientRect();
     const rectB = second.getBoundingClientRect();
     const { pointA: a, pointB: b, xGap, yGap } = getEdgeData(rectA, rectB);
-
-    const svgNS = 'http://www.w3.org/2000/svg';
     const svgEl = connectorLine as unknown as HTMLElement;
 
-    // Reset all labels
     distanceLabel.style.display = 'none';
     xDistanceLabel.style.display = 'none';
     yDistanceLabel.style.display = 'none';
@@ -392,7 +602,6 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
       return;
     }
 
-    // Size the SVG to cover the viewport
     svgEl.style.position = 'fixed';
     svgEl.style.top = '0';
     svgEl.style.left = '0';
@@ -404,299 +613,59 @@ import { RUNTIME_MESSAGES, RuntimeMessage } from 'types/runtime-messages';
       `0 0 ${window.innerWidth} ${window.innerHeight}`,
     );
 
-    // Clear previous SVG content
     while (connectorLine.firstChild) {
       connectorLine.removeChild(connectorLine.firstChild);
     }
 
-    // Draw corner guidelines for both elements (behind connector lines)
     drawGuidelines(rectA);
     drawGuidelines(rectB);
 
     if (xGap > 0 && yGap > 0) {
-      // L-shaped connector: horizontal segment then vertical segment
-      // Corner sits at (b.x, a.y) — horizontal from A, then vertical to B
-      const corner = { x: b.x, y: a.y };
-
-      const drawSegment = (
-        x1: number,
-        y1: number,
-        x2: number,
-        y2: number,
-      ): void => {
-        const seg = document.createElementNS(svgNS, 'line');
-        seg.setAttribute('x1', String(x1));
-        seg.setAttribute('y1', String(y1));
-        seg.setAttribute('x2', String(x2));
-        seg.setAttribute('y2', String(y2));
-        seg.setAttribute('stroke', CONNECTOR_COLOR);
-        seg.setAttribute('stroke-width', '2');
-        seg.setAttribute('stroke-dasharray', '6 4');
-        connectorLine!.appendChild(seg);
-      };
-
-      // Horizontal: A edge → corner
-      drawSegment(a.x, a.y, corner.x, corner.y);
-      // Vertical: corner → B edge
-      drawSegment(corner.x, corner.y, b.x, b.y);
-
-      // Endpoint circles at A and B
-      [a, b].forEach(point => {
-        const circle = document.createElementNS(svgNS, 'circle');
-        circle.setAttribute('cx', String(point.x));
-        circle.setAttribute('cy', String(point.y));
-        circle.setAttribute('r', '4');
-        circle.setAttribute('fill', CONNECTOR_COLOR);
-        connectorLine!.appendChild(circle);
-      });
-
-      // Small dot at the corner
-      const cornerDot = document.createElementNS(svgNS, 'circle');
-      cornerDot.setAttribute('cx', String(corner.x));
-      cornerDot.setAttribute('cy', String(corner.y));
-      cornerDot.setAttribute('r', '3');
-      cornerDot.setAttribute('fill', CONNECTOR_COLOR);
-      cornerDot.setAttribute('opacity', '0.5');
-      connectorLine.appendChild(cornerDot);
-
-      // X label centred on the horizontal segment
-      xDistanceLabel.textContent = `${Math.round(xGap)}px`;
-      xDistanceLabel.style.position = 'fixed';
-      xDistanceLabel.style.left = `${(a.x + corner.x) / 2}px`;
-      xDistanceLabel.style.top = `${a.y}px`;
-      xDistanceLabel.style.display = 'block';
-
-      // Y label centred on the vertical segment
-      yDistanceLabel.textContent = `${Math.round(yGap)}px`;
-      yDistanceLabel.style.position = 'fixed';
-      yDistanceLabel.style.left = `${corner.x}px`;
-      yDistanceLabel.style.top = `${(corner.y + b.y) / 2}px`;
-      yDistanceLabel.style.display = 'block';
+      drawLShaped(a, b, xGap, yGap);
     } else if (
       xGap === 0 &&
       yGap > 0 &&
-      (Math.abs(rectA.left - rectB.left) > 1 ||
-        Math.abs(rectA.right - rectB.right) > 1)
+      (Math.abs(rectA.left - rectB.left) > EDGE_EPSILON ||
+        Math.abs(rectA.right - rectB.right) > EDGE_EPSILON)
     ) {
-      // Both-edges case: elements overlap on x-axis but have misaligned edges.
-      // Show left/right edge gaps and the y-gap separately.
-      const leftEdgeDiff = Math.abs(rectA.left - rectB.left);
-      const rightEdgeDiff = Math.abs(rectA.right - rectB.right);
-      const yBetween = (a.y + b.y) / 2;
-      const rectACenterY = rectA.top + rectA.height / 2;
-      const rectBCenterY = rectB.top + rectB.height / 2;
-      // For each side, anchor the gap line to the centre of whichever element
-      // is inset (the "smaller" side) so the line runs through that element.
-      const leftGapY = rectA.left > rectB.left ? rectACenterY : rectBCenterY;
-      const rightGapY = rectA.right < rectB.right ? rectACenterY : rectBCenterY;
-
-      const drawEdgeSeg = (
-        x1: number,
-        y1: number,
-        x2: number,
-        y2: number,
-      ): void => {
-        const seg = document.createElementNS(svgNS, 'line');
-        seg.setAttribute('x1', String(x1));
-        seg.setAttribute('y1', String(y1));
-        seg.setAttribute('x2', String(x2));
-        seg.setAttribute('y2', String(y2));
-        seg.setAttribute('stroke', CONNECTOR_COLOR);
-        seg.setAttribute('stroke-width', '2');
-        seg.setAttribute('stroke-dasharray', '6 4');
-        connectorLine!.appendChild(seg);
-      };
-
-      const drawEdgeCircle = (cx: number, cy: number): void => {
-        const circle = document.createElementNS(svgNS, 'circle');
-        circle.setAttribute('cx', String(cx));
-        circle.setAttribute('cy', String(cy));
-        circle.setAttribute('r', '4');
-        circle.setAttribute('fill', CONNECTOR_COLOR);
-        connectorLine!.appendChild(circle);
-      };
-
-      // Vertical y-gap line at the horizontal midpoint of the overlap
-      drawEdgeSeg(a.x, a.y, a.x, b.y);
-      drawEdgeCircle(a.x, a.y);
-      drawEdgeCircle(a.x, b.y);
-
-      yDistanceLabel.textContent = `${Math.round(yGap)}px`;
-      yDistanceLabel.style.position = 'fixed';
-      yDistanceLabel.style.left = `${a.x}px`;
-      yDistanceLabel.style.top = `${yBetween}px`;
-      yDistanceLabel.style.display = 'block';
-
-      // Left edge gap — anchored to the centre of the inset element
-      if (leftEdgeDiff > 1) {
-        const leftFrom = Math.min(rectA.left, rectB.left);
-        const leftTo = Math.max(rectA.left, rectB.left);
-        drawEdgeSeg(leftFrom, leftGapY, leftTo, leftGapY);
-        drawEdgeCircle(leftFrom, leftGapY);
-        drawEdgeCircle(leftTo, leftGapY);
-        xDistanceLabel.textContent = `${Math.round(leftEdgeDiff)}px`;
-        xDistanceLabel.style.position = 'fixed';
-        xDistanceLabel.style.left = `${(leftFrom + leftTo) / 2}px`;
-        xDistanceLabel.style.top = `${leftGapY}px`;
-        xDistanceLabel.style.display = 'block';
-      }
-
-      // Right edge gap — anchored to the centre of the inset element
-      if (rightEdgeDiff > 1) {
-        const rightFrom = Math.min(rectA.right, rectB.right);
-        const rightTo = Math.max(rectA.right, rectB.right);
-        drawEdgeSeg(rightFrom, rightGapY, rightTo, rightGapY);
-        drawEdgeCircle(rightFrom, rightGapY);
-        drawEdgeCircle(rightTo, rightGapY);
-        distanceLabel.textContent = `${Math.round(rightEdgeDiff)}px`;
-        distanceLabel.style.position = 'fixed';
-        distanceLabel.style.left = `${(rightFrom + rightTo) / 2}px`;
-        distanceLabel.style.top = `${rightGapY}px`;
-        distanceLabel.style.display = 'block';
-      }
+      drawHEdgeMisalign(rectA, rectB, a, b, yGap);
     } else if (
       yGap === 0 &&
       xGap > 0 &&
-      (Math.abs(rectA.top - rectB.top) > 1 ||
-        Math.abs(rectA.bottom - rectB.bottom) > 1)
+      (Math.abs(rectA.top - rectB.top) > EDGE_EPSILON ||
+        Math.abs(rectA.bottom - rectB.bottom) > EDGE_EPSILON)
     ) {
-      // Vertical both-edges case: elements overlap on y-axis but have misaligned
-      // top/bottom edges. Show top/bottom edge gaps alongside the x-gap.
-      const topEdgeDiff = Math.abs(rectA.top - rectB.top);
-      const bottomEdgeDiff = Math.abs(rectA.bottom - rectB.bottom);
-      const xBetween = (a.x + b.x) / 2;
-      const rectACenterX = rectA.left + rectA.width / 2;
-      const rectBCenterX = rectB.left + rectB.width / 2;
-      // Anchor each edge gap line to the x-centre of the inset element
-      const topGapX = rectA.top > rectB.top ? rectACenterX : rectBCenterX;
-      const bottomGapX =
-        rectA.bottom < rectB.bottom ? rectACenterX : rectBCenterX;
-
-      const drawVSeg = (
-        x1: number,
-        y1: number,
-        x2: number,
-        y2: number,
-      ): void => {
-        const seg = document.createElementNS(svgNS, 'line');
-        seg.setAttribute('x1', String(x1));
-        seg.setAttribute('y1', String(y1));
-        seg.setAttribute('x2', String(x2));
-        seg.setAttribute('y2', String(y2));
-        seg.setAttribute('stroke', CONNECTOR_COLOR);
-        seg.setAttribute('stroke-width', '2');
-        seg.setAttribute('stroke-dasharray', '6 4');
-        connectorLine!.appendChild(seg);
-      };
-
-      const drawVCircle = (cx: number, cy: number): void => {
-        const circle = document.createElementNS(svgNS, 'circle');
-        circle.setAttribute('cx', String(cx));
-        circle.setAttribute('cy', String(cy));
-        circle.setAttribute('r', '4');
-        circle.setAttribute('fill', CONNECTOR_COLOR);
-        connectorLine!.appendChild(circle);
-      };
-
-      // Horizontal x-gap line at the vertical midpoint of the overlap
-      drawVSeg(a.x, a.y, b.x, b.y);
-      drawVCircle(a.x, a.y);
-      drawVCircle(b.x, b.y);
-
-      distanceLabel.textContent = `${Math.round(xGap)}px`;
-      distanceLabel.style.position = 'fixed';
-      distanceLabel.style.left = `${xBetween}px`;
-      distanceLabel.style.top = `${a.y}px`;
-      distanceLabel.style.display = 'block';
-
-      // Top edge gap — anchored to the x-centre of the inset element
-      if (topEdgeDiff > 1) {
-        const topFrom = Math.min(rectA.top, rectB.top);
-        const topTo = Math.max(rectA.top, rectB.top);
-        drawVSeg(topGapX, topFrom, topGapX, topTo);
-        drawVCircle(topGapX, topFrom);
-        drawVCircle(topGapX, topTo);
-        xDistanceLabel.textContent = `${Math.round(topEdgeDiff)}px`;
-        xDistanceLabel.style.position = 'fixed';
-        xDistanceLabel.style.left = `${topGapX}px`;
-        xDistanceLabel.style.top = `${(topFrom + topTo) / 2}px`;
-        xDistanceLabel.style.display = 'block';
-      }
-
-      // Bottom edge gap — anchored to the x-centre of the inset element
-      if (bottomEdgeDiff > 1) {
-        const bottomFrom = Math.min(rectA.bottom, rectB.bottom);
-        const bottomTo = Math.max(rectA.bottom, rectB.bottom);
-        drawVSeg(bottomGapX, bottomFrom, bottomGapX, bottomTo);
-        drawVCircle(bottomGapX, bottomFrom);
-        drawVCircle(bottomGapX, bottomTo);
-        yDistanceLabel.textContent = `${Math.round(bottomEdgeDiff)}px`;
-        yDistanceLabel.style.position = 'fixed';
-        yDistanceLabel.style.left = `${bottomGapX}px`;
-        yDistanceLabel.style.top = `${(bottomFrom + bottomTo) / 2}px`;
-        yDistanceLabel.style.display = 'block';
-      }
+      drawVEdgeMisalign(rectA, rectB, a, b, xGap);
     } else {
-      // Single-axis: one straight line with one label
-      const line = document.createElementNS(svgNS, 'line');
-      line.setAttribute('x1', String(a.x));
-      line.setAttribute('y1', String(a.y));
-      line.setAttribute('x2', String(b.x));
-      line.setAttribute('y2', String(b.y));
-      line.setAttribute('stroke', CONNECTOR_COLOR);
-      line.setAttribute('stroke-width', '2');
-      line.setAttribute('stroke-dasharray', '6 4');
-      connectorLine.appendChild(line);
-
-      [a, b].forEach(point => {
-        const circle = document.createElementNS(svgNS, 'circle');
-        circle.setAttribute('cx', String(point.x));
-        circle.setAttribute('cy', String(point.y));
-        circle.setAttribute('r', '4');
-        circle.setAttribute('fill', CONNECTOR_COLOR);
-        connectorLine!.appendChild(circle);
-      });
-
-      const dist = xGap > 0 ? Math.round(xGap) : Math.round(yGap);
-      distanceLabel.textContent = `${dist}px`;
-      distanceLabel.style.position = 'fixed';
-      distanceLabel.style.left = `${(a.x + b.x) / 2}px`;
-      distanceLabel.style.top = `${(a.y + b.y) / 2}px`;
-      distanceLabel.style.display = 'block';
+      drawSingleAxis(a, b, xGap, yGap);
     }
   }
 
   /**
-   * Draws thin guideline extensions from each corner of the given rect to the
-   * viewport edges. Called as part of drawConnector so guidelines appear behind
-   * the connector lines in the SVG paint order.
+   * Draws thin dashed guideline extensions from each corner of the given rect
+   * to the viewport edges. Called for both elements so connector lines always
+   * originate from a visible guideline.
    *
-   * @param rect - The bounding rect of the second (hovered or locked) element.
+   * @param rect - The bounding rect of an element to draw guidelines for.
    */
   function drawGuidelines(rect: DOMRect): void {
     if (!connectorLine) return;
-    const svgNS = 'http://www.w3.org/2000/svg';
     const vw = window.innerWidth;
     const vh = window.innerHeight;
 
-    // 8 segments: from each of the 4 corners, one horizontal + one vertical
     const segments: [number, number, number, number][] = [
-      // Top-left corner
-      [0, rect.top, rect.left, rect.top], // left to viewport left edge
-      [rect.left, 0, rect.left, rect.top], // up to viewport top edge
-      // Top-right corner
-      [rect.right, rect.top, vw, rect.top], // right to viewport right edge
-      [rect.right, 0, rect.right, rect.top], // up to viewport top edge
-      // Bottom-left corner
-      [0, rect.bottom, rect.left, rect.bottom], // left to viewport left edge
-      [rect.left, rect.bottom, rect.left, vh], // down to viewport bottom edge
-      // Bottom-right corner
-      [rect.right, rect.bottom, vw, rect.bottom], // right to viewport right edge
-      [rect.right, rect.bottom, rect.right, vh], // down to viewport bottom edge
+      [0, rect.top, rect.left, rect.top],
+      [rect.left, 0, rect.left, rect.top],
+      [rect.right, rect.top, vw, rect.top],
+      [rect.right, 0, rect.right, rect.top],
+      [0, rect.bottom, rect.left, rect.bottom],
+      [rect.left, rect.bottom, rect.left, vh],
+      [rect.right, rect.bottom, vw, rect.bottom],
+      [rect.right, rect.bottom, rect.right, vh],
     ];
 
     segments.forEach(([x1, y1, x2, y2]) => {
-      const line = document.createElementNS(svgNS, 'line');
+      const line = document.createElementNS(SVG_NS, 'line');
       line.setAttribute('x1', String(x1));
       line.setAttribute('y1', String(y1));
       line.setAttribute('x2', String(x2));

--- a/src/scripts/utils/measurement-geometry.ts
+++ b/src/scripts/utils/measurement-geometry.ts
@@ -1,0 +1,58 @@
+import { EdgeData } from 'types/scripts/measurement';
+
+/**
+ * Minimum pixel difference required before an edge misalignment is rendered.
+ * Used to suppress noise from sub-pixel layout differences.
+ */
+export const EDGE_EPSILON = 1;
+
+/**
+ * Returns the nearest edge anchor points between two DOMRects along with
+ * the individual horizontal and vertical gap distances between them.
+ *
+ * @param a - The first element's bounding rect.
+ * @param b - The second element's bounding rect.
+ * @returns Edge anchor points on each rect and the x/y gap values.
+ */
+export function getEdgeData(a: DOMRect, b: DOMRect): EdgeData {
+  // Horizontal component
+  let ax: number, bx: number, xGap: number;
+  if (a.right <= b.left) {
+    ax = a.right;
+    bx = b.left;
+    xGap = b.left - a.right;
+  } else if (b.right <= a.left) {
+    ax = a.left;
+    bx = b.right;
+    xGap = a.left - b.right;
+  } else {
+    const xMid = (Math.max(a.left, b.left) + Math.min(a.right, b.right)) / 2;
+    ax = xMid;
+    bx = xMid;
+    xGap = 0;
+  }
+
+  // Vertical component
+  let ay: number, by: number, yGap: number;
+  if (a.bottom <= b.top) {
+    ay = a.bottom;
+    by = b.top;
+    yGap = b.top - a.bottom;
+  } else if (b.bottom <= a.top) {
+    ay = a.top;
+    by = b.bottom;
+    yGap = a.top - b.bottom;
+  } else {
+    const yMid = (Math.max(a.top, b.top) + Math.min(a.bottom, b.bottom)) / 2;
+    ay = yMid;
+    by = yMid;
+    yGap = 0;
+  }
+
+  return {
+    pointA: { x: ax, y: ay },
+    pointB: { x: bx, y: by },
+    xGap,
+    yGap,
+  };
+}

--- a/src/scripts/utils/measurement-svg.ts
+++ b/src/scripts/utils/measurement-svg.ts
@@ -1,0 +1,309 @@
+import { Point, MeasurementLabelRefs } from 'types/scripts/measurement';
+import { EDGE_EPSILON } from './measurement-geometry';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+export const CONNECTOR_COLOR = '#ef4444';
+export const GUIDELINE_COLOR = 'rgba(148, 163, 184, 0.3)';
+
+// ---------------------------------------------------------------------------
+// SVG primitive helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Appends a dashed connector line between two points to the given SVG element.
+ *
+ * @param svg - The SVG element to append to.
+ * @param x1 - Start x coordinate.
+ * @param y1 - Start y coordinate.
+ * @param x2 - End x coordinate.
+ * @param y2 - End y coordinate.
+ */
+export function appendConnectorLine(
+  svg: SVGElement,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+): void {
+  const el = document.createElementNS(SVG_NS, 'line');
+  el.setAttribute('x1', String(x1));
+  el.setAttribute('y1', String(y1));
+  el.setAttribute('x2', String(x2));
+  el.setAttribute('y2', String(y2));
+  el.setAttribute('stroke', CONNECTOR_COLOR);
+  el.setAttribute('stroke-width', '2');
+  el.setAttribute('stroke-dasharray', '6 4');
+  svg.appendChild(el);
+}
+
+/**
+ * Appends a filled circle endpoint to the given SVG element.
+ *
+ * @param svg - The SVG element to append to.
+ * @param cx - Centre x coordinate.
+ * @param cy - Centre y coordinate.
+ * @param r - Radius (default 4).
+ * @param opacity - Optional opacity value as a string.
+ */
+export function appendConnectorDot(
+  svg: SVGElement,
+  cx: number,
+  cy: number,
+  r = 4,
+  opacity?: string,
+): void {
+  const el = document.createElementNS(SVG_NS, 'circle');
+  el.setAttribute('cx', String(cx));
+  el.setAttribute('cy', String(cy));
+  el.setAttribute('r', String(r));
+  el.setAttribute('fill', CONNECTOR_COLOR);
+  if (opacity !== undefined) el.setAttribute('opacity', opacity);
+  svg.appendChild(el);
+}
+
+// ---------------------------------------------------------------------------
+// Connector branch functions — each handles one measurement layout
+// ---------------------------------------------------------------------------
+
+/**
+ * Draws thin dashed guideline extensions from each corner of the given rect
+ * to the viewport edges. Call for both elements so connector lines always
+ * originate from a visible guideline.
+ *
+ * @param svg - The SVG overlay element to draw into.
+ * @param rect - The bounding rect of the element to draw guidelines for.
+ */
+export function drawGuidelines(svg: SVGElement, rect: DOMRect): void {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  const segments: [number, number, number, number][] = [
+    [0, rect.top, rect.left, rect.top],
+    [rect.left, 0, rect.left, rect.top],
+    [rect.right, rect.top, vw, rect.top],
+    [rect.right, 0, rect.right, rect.top],
+    [0, rect.bottom, rect.left, rect.bottom],
+    [rect.left, rect.bottom, rect.left, vh],
+    [rect.right, rect.bottom, vw, rect.bottom],
+    [rect.right, rect.bottom, rect.right, vh],
+  ];
+
+  segments.forEach(([x1, y1, x2, y2]) => {
+    const line = document.createElementNS(SVG_NS, 'line');
+    line.setAttribute('x1', String(x1));
+    line.setAttribute('y1', String(y1));
+    line.setAttribute('x2', String(x2));
+    line.setAttribute('y2', String(y2));
+    line.setAttribute('stroke', GUIDELINE_COLOR);
+    line.setAttribute('stroke-width', '1');
+    line.setAttribute('stroke-dasharray', '4 4');
+    svg.appendChild(line);
+  });
+}
+
+/**
+ * L-shaped connector for elements offset on both axes.
+ *
+ * @param svg - The SVG overlay element.
+ * @param labels - Distance label DOM references.
+ * @param a - Anchor point on the first element.
+ * @param b - Anchor point on the second element.
+ * @param xGap - Horizontal gap in pixels.
+ * @param yGap - Vertical gap in pixels.
+ */
+export function drawLShaped(
+  svg: SVGElement,
+  labels: MeasurementLabelRefs,
+  a: Point,
+  b: Point,
+  xGap: number,
+  yGap: number,
+): void {
+  const corner = { x: b.x, y: a.y };
+  appendConnectorLine(svg, a.x, a.y, corner.x, corner.y);
+  appendConnectorLine(svg, corner.x, corner.y, b.x, b.y);
+  appendConnectorDot(svg, a.x, a.y);
+  appendConnectorDot(svg, b.x, b.y);
+  appendConnectorDot(svg, corner.x, corner.y, 3, '0.5');
+
+  const { xDistanceLabel, yDistanceLabel } = labels;
+
+  xDistanceLabel.textContent = `${Math.round(xGap)}px`;
+  xDistanceLabel.style.position = 'fixed';
+  xDistanceLabel.style.left = `${(a.x + corner.x) / 2}px`;
+  xDistanceLabel.style.top = `${a.y}px`;
+  xDistanceLabel.style.display = 'block';
+
+  yDistanceLabel.textContent = `${Math.round(yGap)}px`;
+  yDistanceLabel.style.position = 'fixed';
+  yDistanceLabel.style.left = `${corner.x}px`;
+  yDistanceLabel.style.top = `${(corner.y + b.y) / 2}px`;
+  yDistanceLabel.style.display = 'block';
+}
+
+/**
+ * Horizontal edge-misalignment layout: elements are vertically separated with
+ * horizontal overlap but misaligned left/right edges. Renders the y-gap line
+ * plus horizontal segments for each edge difference exceeding EDGE_EPSILON.
+ *
+ * @param svg - The SVG overlay element.
+ * @param labels - Distance label DOM references.
+ * @param rectA - Bounding rect of the first element.
+ * @param rectB - Bounding rect of the second element.
+ * @param a - Anchor point on the first element.
+ * @param b - Anchor point on the second element.
+ * @param yGap - Vertical gap in pixels.
+ */
+export function drawHEdgeMisalign(
+  svg: SVGElement,
+  labels: MeasurementLabelRefs,
+  rectA: DOMRect,
+  rectB: DOMRect,
+  a: Point,
+  b: Point,
+  yGap: number,
+): void {
+  const leftEdgeDiff = Math.abs(rectA.left - rectB.left);
+  const rightEdgeDiff = Math.abs(rectA.right - rectB.right);
+  const yBetween = (a.y + b.y) / 2;
+  const rectACenterY = rectA.top + rectA.height / 2;
+  const rectBCenterY = rectB.top + rectB.height / 2;
+  const leftGapY = rectA.left > rectB.left ? rectACenterY : rectBCenterY;
+  const rightGapY = rectA.right < rectB.right ? rectACenterY : rectBCenterY;
+
+  const { distanceLabel, xDistanceLabel, yDistanceLabel } = labels;
+
+  appendConnectorLine(svg, a.x, a.y, a.x, b.y);
+  appendConnectorDot(svg, a.x, a.y);
+  appendConnectorDot(svg, a.x, b.y);
+
+  yDistanceLabel.textContent = `${Math.round(yGap)}px`;
+  yDistanceLabel.style.position = 'fixed';
+  yDistanceLabel.style.left = `${a.x}px`;
+  yDistanceLabel.style.top = `${yBetween}px`;
+  yDistanceLabel.style.display = 'block';
+
+  if (leftEdgeDiff > EDGE_EPSILON) {
+    const leftFrom = Math.min(rectA.left, rectB.left);
+    const leftTo = Math.max(rectA.left, rectB.left);
+    appendConnectorLine(svg, leftFrom, leftGapY, leftTo, leftGapY);
+    appendConnectorDot(svg, leftFrom, leftGapY);
+    appendConnectorDot(svg, leftTo, leftGapY);
+    xDistanceLabel.textContent = `${Math.round(leftEdgeDiff)}px`;
+    xDistanceLabel.style.position = 'fixed';
+    xDistanceLabel.style.left = `${(leftFrom + leftTo) / 2}px`;
+    xDistanceLabel.style.top = `${leftGapY}px`;
+    xDistanceLabel.style.display = 'block';
+  }
+
+  if (rightEdgeDiff > EDGE_EPSILON) {
+    const rightFrom = Math.min(rectA.right, rectB.right);
+    const rightTo = Math.max(rectA.right, rectB.right);
+    appendConnectorLine(svg, rightFrom, rightGapY, rightTo, rightGapY);
+    appendConnectorDot(svg, rightFrom, rightGapY);
+    appendConnectorDot(svg, rightTo, rightGapY);
+    distanceLabel.textContent = `${Math.round(rightEdgeDiff)}px`;
+    distanceLabel.style.position = 'fixed';
+    distanceLabel.style.left = `${(rightFrom + rightTo) / 2}px`;
+    distanceLabel.style.top = `${rightGapY}px`;
+    distanceLabel.style.display = 'block';
+  }
+}
+
+/**
+ * Vertical edge-misalignment layout: elements are horizontally separated with
+ * vertical overlap but misaligned top/bottom edges. Renders the x-gap line
+ * plus vertical segments for each edge difference exceeding EDGE_EPSILON.
+ *
+ * @param svg - The SVG overlay element.
+ * @param labels - Distance label DOM references.
+ * @param rectA - Bounding rect of the first element.
+ * @param rectB - Bounding rect of the second element.
+ * @param a - Anchor point on the first element.
+ * @param b - Anchor point on the second element.
+ * @param xGap - Horizontal gap in pixels.
+ */
+export function drawVEdgeMisalign(
+  svg: SVGElement,
+  labels: MeasurementLabelRefs,
+  rectA: DOMRect,
+  rectB: DOMRect,
+  a: Point,
+  b: Point,
+  xGap: number,
+): void {
+  const topEdgeDiff = Math.abs(rectA.top - rectB.top);
+  const bottomEdgeDiff = Math.abs(rectA.bottom - rectB.bottom);
+  const xBetween = (a.x + b.x) / 2;
+  const rectACenterX = rectA.left + rectA.width / 2;
+  const rectBCenterX = rectB.left + rectB.width / 2;
+  const topGapX = rectA.top > rectB.top ? rectACenterX : rectBCenterX;
+  const bottomGapX = rectA.bottom < rectB.bottom ? rectACenterX : rectBCenterX;
+
+  const { distanceLabel, xDistanceLabel, yDistanceLabel } = labels;
+
+  appendConnectorLine(svg, a.x, a.y, b.x, b.y);
+  appendConnectorDot(svg, a.x, a.y);
+  appendConnectorDot(svg, b.x, b.y);
+
+  distanceLabel.textContent = `${Math.round(xGap)}px`;
+  distanceLabel.style.position = 'fixed';
+  distanceLabel.style.left = `${xBetween}px`;
+  distanceLabel.style.top = `${a.y}px`;
+  distanceLabel.style.display = 'block';
+
+  if (topEdgeDiff > EDGE_EPSILON) {
+    const topFrom = Math.min(rectA.top, rectB.top);
+    const topTo = Math.max(rectA.top, rectB.top);
+    appendConnectorLine(svg, topGapX, topFrom, topGapX, topTo);
+    appendConnectorDot(svg, topGapX, topFrom);
+    appendConnectorDot(svg, topGapX, topTo);
+    xDistanceLabel.textContent = `${Math.round(topEdgeDiff)}px`;
+    xDistanceLabel.style.position = 'fixed';
+    xDistanceLabel.style.left = `${topGapX}px`;
+    xDistanceLabel.style.top = `${(topFrom + topTo) / 2}px`;
+    xDistanceLabel.style.display = 'block';
+  }
+
+  if (bottomEdgeDiff > EDGE_EPSILON) {
+    const bottomFrom = Math.min(rectA.bottom, rectB.bottom);
+    const bottomTo = Math.max(rectA.bottom, rectB.bottom);
+    appendConnectorLine(svg, bottomGapX, bottomFrom, bottomGapX, bottomTo);
+    appendConnectorDot(svg, bottomGapX, bottomFrom);
+    appendConnectorDot(svg, bottomGapX, bottomTo);
+    yDistanceLabel.textContent = `${Math.round(bottomEdgeDiff)}px`;
+    yDistanceLabel.style.position = 'fixed';
+    yDistanceLabel.style.left = `${bottomGapX}px`;
+    yDistanceLabel.style.top = `${(bottomFrom + bottomTo) / 2}px`;
+    yDistanceLabel.style.display = 'block';
+  }
+}
+
+/**
+ * Single dashed line with one distance label for pure x or y separation.
+ *
+ * @param svg - The SVG overlay element.
+ * @param labels - Distance label DOM references.
+ * @param a - Anchor point on the first element.
+ * @param b - Anchor point on the second element.
+ * @param xGap - Horizontal gap in pixels.
+ * @param yGap - Vertical gap in pixels.
+ */
+export function drawSingleAxis(
+  svg: SVGElement,
+  labels: MeasurementLabelRefs,
+  a: Point,
+  b: Point,
+  xGap: number,
+  yGap: number,
+): void {
+  appendConnectorLine(svg, a.x, a.y, b.x, b.y);
+  appendConnectorDot(svg, a.x, a.y);
+  appendConnectorDot(svg, b.x, b.y);
+  const dist = xGap > 0 ? Math.round(xGap) : Math.round(yGap);
+  labels.distanceLabel.textContent = `${dist}px`;
+  labels.distanceLabel.style.position = 'fixed';
+  labels.distanceLabel.style.left = `${(a.x + b.x) / 2}px`;
+  labels.distanceLabel.style.top = `${(a.y + b.y) / 2}px`;
+  labels.distanceLabel.style.display = 'block';
+}

--- a/src/types/scripts/measurement.d.ts
+++ b/src/types/scripts/measurement.d.ts
@@ -1,0 +1,35 @@
+/**
+ * A 2D point in viewport coordinates.
+ */
+export type Point = {
+  x: number;
+  y: number;
+};
+
+/**
+ * Computed gap distances and nearest edge anchor points between two elements.
+ *
+ * @property pointA - Anchor point on the first element's nearest edge.
+ * @property pointB - Anchor point on the second element's nearest edge.
+ * @property xGap - Horizontal gap in pixels (0 if elements overlap horizontally).
+ * @property yGap - Vertical gap in pixels (0 if elements overlap vertically).
+ */
+export type EdgeData = {
+  pointA: Point;
+  pointB: Point;
+  xGap: number;
+  yGap: number;
+};
+
+/**
+ * References to the three distance label DOM elements used by the connector.
+ *
+ * @property distanceLabel - Label for single-axis distance or right edge gap.
+ * @property xDistanceLabel - Label for x-distance, left edge gap, or top edge gap.
+ * @property yDistanceLabel - Label for y-distance or bottom edge gap.
+ */
+export type MeasurementLabelRefs = {
+  distanceLabel: HTMLElement;
+  xDistanceLabel: HTMLElement;
+  yDistanceLabel: HTMLElement;
+};


### PR DESCRIPTION
# Overview:

This PR enhances Measurement Mode’s UX by adding a live “second element” preview after the first click and by rendering corner-to-viewport guidelines to aid alignment context while measuring.

**Changes:**
- Add live measurement preview when hovering elements after the first selection (before locking the second selection).
- Render dashed corner guidelines to viewport edges for both elements during measurement, plus additional edge-gap labeling in certain overlap/misalignment cases.
- Document the behavior update in `CHANGELOG.md` under an Unreleased section.
