### PR TITLE
Update Toggle Switch to On/Off with Translations and Added Japanese Translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Shortened toggle switch labels to On/Off (localised: Ein/Aus in German, Activado/Desactivado in Spanish, Activé/Désactivé in French) for a more compact UI.
 - Measurement mode now shows a live distance preview as you move the mouse after selecting the first element, so you can quickly gauge distances without a second click. Clicking a second element locks the measurement in place as before.
 - Hovering over the second element now shows dashed corner guidelines extending to the viewport edges for alignment context. When the second element is wider than the first, left and right edge gap measurements are shown in addition to the vertical distance.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added support for Japanese (JA) localisation, expanding accessibility for Japanese-speaking users.
+- Added a live distance preview in Measurement Mode, allowing users to see real-time measurements as they move the mouse after selecting the first element, enhancing usability and efficiency.
+- Added dashed corner guidelines in Measurement Mode when hovering over the second element, providing better alignment context. When the second element is wider than the first, left and right edge gap measurements are also displayed for improved spatial understanding.
+
 ### Changed
 
-- Shortened toggle switch labels to On/Off (localised: Ein/Aus in German, Activado/Desactivado in Spanish, Activé/Désactivé in French) for a more compact UI.
-- Measurement mode now shows a live distance preview as you move the mouse after selecting the first element, so you can quickly gauge distances without a second click. Clicking a second element locks the measurement in place as before.
-- Hovering over the second element now shows dashed corner guidelines extending to the viewport edges for alignment context. When the second element is wider than the first, left and right edge gap measurements are shown in addition to the vertical distance.
+- Shortened toggle switch labels to On/Off for a more compact UI.
 
 ## [1.7.2] - 2026-04-09
 

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -64,11 +64,11 @@
     "description": "A double border style."
   },
   "enabled": {
-    "message": "Aktiviert",
+    "message": "Ein",
     "description": "Indicates that a feature or option is turned on."
   },
   "disabled": {
-    "message": "Deaktiviert",
+    "message": "Aus",
     "description": "Indicates that a feature or option is turned off."
   },
   "enableOrDisableBorders": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -64,11 +64,11 @@
     "description": "A double border style."
   },
   "enabled": {
-    "message": "Enabled",
+    "message": "On",
     "description": "Indicates that a feature or option is turned on."
   },
   "disabled": {
-    "message": "Disabled",
+    "message": "Off",
     "description": "Indicates that a feature or option is turned off."
   },
   "enableOrDisableBorders": {

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -64,11 +64,11 @@
     "description": "A double border style."
   },
   "enabled": {
-    "message": "On",
+    "message": "Activado",
     "description": "Indicates that a feature or option is turned on."
   },
   "disabled": {
-    "message": "Off",
+    "message": "Desactivado",
     "description": "Indicates that a feature or option is turned off."
   },
   "enableOrDisableBorders": {

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -64,11 +64,11 @@
     "description": "A double border style."
   },
   "enabled": {
-    "message": "Habilitado",
+    "message": "On",
     "description": "Indicates that a feature or option is turned on."
   },
   "disabled": {
-    "message": "Deshabilitado",
+    "message": "Off",
     "description": "Indicates that a feature or option is turned off."
   },
   "enableOrDisableBorders": {

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -64,11 +64,11 @@
     "description": "A double border style."
   },
   "enabled": {
-    "message": "On",
+    "message": "Activé",
     "description": "Indicates that a feature or option is turned on."
   },
   "disabled": {
-    "message": "Off",
+    "message": "Désactivé",
     "description": "Indicates that a feature or option is turned off."
   },
   "enableOrDisableBorders": {

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -64,11 +64,11 @@
     "description": "A double border style."
   },
   "enabled": {
-    "message": "Activé",
+    "message": "On",
     "description": "Indicates that a feature or option is turned on."
   },
   "disabled": {
-    "message": "Désactivé",
+    "message": "Off",
     "description": "Indicates that a feature or option is turned off."
   },
   "enableOrDisableBorders": {

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1,0 +1,182 @@
+{
+  "extensionName": {
+    "message": "Border Patrol",
+    "description": "The brand name of the extension."
+  },
+  "extensionLongName": {
+    "message": "Border Patrol – CSSデバッガー & 要素アウトライナー",
+    "description": "The long brand name of the extension."
+  },
+  "extensionDescription": {
+    "message": "CSSボックスモデルデバッガー & 要素アウトライナー — UIの素早い検証、レイアウトの可視化、フロントエンド開発の効率化に。",
+    "description": "Extension description for manifest.json and Web Store SEO."
+  },
+  "toggleBorderModeCommand": {
+    "message": "ボーダーモードを切り替える",
+    "description": "Command description for toggling Border Mode in manifest."
+  },
+  "toggleInspectorModeCommand": {
+    "message": "インスペクターモードを切り替える",
+    "description": "Command description for toggling Inspector Mode in manifest."
+  },
+  "borderSettings": {
+    "message": "ボーダー設定",
+    "description": "Title for the border settings section."
+  },
+  "borderMode": {
+    "message": "ボーダーモード",
+    "description": "Label for selecting the border mode."
+  },
+  "inspectorMode": {
+    "message": "インスペクターモード",
+    "description": "Label for toggling inspector mode."
+  },
+  "borderSize": {
+    "message": "ボーダーサイズ",
+    "description": "Label for selecting the size of the border."
+  },
+  "borderStyle": {
+    "message": "ボーダースタイル",
+    "description": "Label for selecting the style of the border."
+  },
+  "size": {
+    "message": "サイズ",
+    "description": "Generic label for size."
+  },
+  "style": {
+    "message": "スタイル",
+    "description": "Generic label for style."
+  },
+  "solid": {
+    "message": "実線",
+    "description": "A solid border style."
+  },
+  "dashed": {
+    "message": "破線",
+    "description": "A dashed border style."
+  },
+  "dotted": {
+    "message": "点線",
+    "description": "A dotted border style."
+  },
+  "double": {
+    "message": "二重線",
+    "description": "A double border style."
+  },
+  "enabled": {
+    "message": "オン",
+    "description": "Indicates that a feature or option is turned on."
+  },
+  "disabled": {
+    "message": "オフ",
+    "description": "Indicates that a feature or option is turned off."
+  },
+  "enableOrDisableBorders": {
+    "message": "ボーダーの表示を切り替える",
+    "description": "Instruction to enable or disable borders."
+  },
+  "enableOrDisableInspectors": {
+    "message": "インスペクターモードを切り替える",
+    "description": "Instruction to enable or disable inspectors."
+  },
+  "error": {
+    "message": "エラー",
+    "description": "Indicates that an error has occurred."
+  },
+  "restricted": {
+    "message": "制限済み",
+    "description": "Indicates that access is restricted."
+  },
+  "restrictedDescription": {
+    "message": "このページは制限されています。",
+    "description": "Description shown when the extension is restricted from running on a page."
+  },
+  "grantPermission": {
+    "message": "許可を付与",
+    "description": "Button text for granting permission to the extension."
+  },
+  "capturing": {
+    "message": "キャプチャ中",
+    "description": "Indicates that the extension is currently capturing data."
+  },
+  "takeScreenshot": {
+    "message": "スクリーンショットを撮る",
+    "description": "Button text for taking a screenshot."
+  },
+  "screenshotModeVisible": {
+    "message": "表示範囲",
+    "description": "Segmented control option for capturing only the visible area of the page."
+  },
+  "screenshotModeFullPage": {
+    "message": "全ページ",
+    "description": "Segmented control option for capturing the full scrollable page."
+  },
+  "downloadPermissionRequired": {
+    "message": "スクリーンショットにはダウンロード許可が必要です",
+    "description": "Indicates that download permission is required to take screenshots."
+  },
+  "downloadPermissionDenied": {
+    "message": "ダウンロード許可が拒否されました",
+    "description": "Indicates that download permission has been denied."
+  },
+  "keyboardShortcuts": {
+    "message": "キーボードショートカット",
+    "description": "Title for the keyboard shortcuts section."
+  },
+  "switchToDarkMode": {
+    "message": "ダークモードに切り替える",
+    "description": "Button text for switching to dark mode."
+  },
+  "switchToLightMode": {
+    "message": "ライトモードに切り替える",
+    "description": "Button text for switching to light mode."
+  },
+  "currentVersion": {
+    "message": "現在のバージョン: {version}",
+    "description": "Label for displaying the current version of the extension."
+  },
+  "selectLanguage": {
+    "message": "拡張機能の言語を選択します。",
+    "description": "Select for changing the language of the extension."
+  },
+  "none": {
+    "message": "なし",
+    "description": "Indicates that no option is selected."
+  },
+  "measurementMode": {
+    "message": "計測モード",
+    "description": "Label for toggling measurement mode."
+  },
+  "enableOrDisableMeasurement": {
+    "message": "計測モードを切り替える",
+    "description": "Instruction to enable or disable measurement mode."
+  },
+  "measurementFirst": {
+    "message": "1番目",
+    "description": "Badge label for the first selected element in measurement mode."
+  },
+  "measurementSecond": {
+    "message": "2番目",
+    "description": "Badge label for the second selected element in measurement mode."
+  },
+  "toggleMeasurementModeCommand": {
+    "message": "計測モードを切り替える",
+    "description": "Command description for toggling Measurement Mode in manifest."
+  },
+  "rulerMode": {
+    "message": "ルーラーモード",
+    "description": "Label for toggling ruler mode."
+  },
+  "enableOrDisableRuler": {
+    "message": "ルーラーモードを切り替える",
+    "description": "Instruction to enable or disable ruler mode."
+  },
+  "screenshotCaptureInProgress": {
+    "message": "スクリーンショットをキャプチャ中...",
+    "description": "Label shown in the page overlay while a full-page screenshot is being captured."
+  },
+  "toggleRulerModeCommand": {
+    "message": "ルーラーモードを切り替える",
+    "description": "Command description for toggling Ruler Mode in manifest."
+  }
+}

--- a/src/popup/components/Footer.tsx
+++ b/src/popup/components/Footer.tsx
@@ -19,6 +19,7 @@ const localeOptions = [
   { value: 'es', label: 'ES' },
   { value: 'fr', label: 'FR' },
   { value: 'de', label: 'DE' },
+  { value: 'ja', label: 'JA' },
 ];
 
 // Placeholder for version, will be replaced during build

--- a/src/popup/components/Footer.tsx
+++ b/src/popup/components/Footer.tsx
@@ -1,6 +1,6 @@
 import { Layout, Select, Typography } from 'antd';
 import DarkModeToggle from './DarkModeToggle';
-import { useLocaleContext } from '../context/LocaleContext';
+import { useLocaleContext, SUPPORTED_LOCALES } from '../context/LocaleContext';
 import { useTranslation } from '../hooks/useTranslation';
 import { LocaleCode } from '../../types/translations';
 
@@ -14,13 +14,10 @@ const footerStyle: React.CSSProperties = {
   width: '100%',
 };
 
-const localeOptions = [
-  { value: 'en', label: 'EN' },
-  { value: 'es', label: 'ES' },
-  { value: 'fr', label: 'FR' },
-  { value: 'de', label: 'DE' },
-  { value: 'ja', label: 'JA' },
-];
+const localeOptions = SUPPORTED_LOCALES.map(code => ({
+  value: code,
+  label: code.toUpperCase(),
+}));
 
 // Placeholder for version, will be replaced during build
 const version = __BP_APP_VERSION__;

--- a/src/popup/context/LocaleContext.tsx
+++ b/src/popup/context/LocaleContext.tsx
@@ -10,7 +10,7 @@ import {
 export const LOCALE_STORAGE_KEY = 'bp_user_locale';
 
 /** List of supported locales for the extension. */
-export const SUPPORTED_LOCALES: LocaleCode[] = ['en', 'es', 'fr', 'de'];
+export const SUPPORTED_LOCALES: LocaleCode[] = ['en', 'es', 'fr', 'de', 'ja'];
 
 // Create the context for locale management
 const LocaleContext = createContext<ILocaleContext>({

--- a/src/popup/context/LocaleContext.tsx
+++ b/src/popup/context/LocaleContext.tsx
@@ -5,12 +5,13 @@ import {
   ILocaleContext,
   ILocaleProviderProps,
 } from '../../types/translations';
+import { localeMap } from '../locales';
 
 /** Key used to store the user's preferred locale in Chrome storage. */
 export const LOCALE_STORAGE_KEY = 'bp_user_locale';
 
-/** List of supported locales for the extension. */
-export const SUPPORTED_LOCALES: LocaleCode[] = ['en', 'es', 'fr', 'de', 'ja'];
+/** List of supported locales, derived from the locale map. */
+export const SUPPORTED_LOCALES = Object.keys(localeMap) as LocaleCode[];
 
 // Create the context for locale management
 const LocaleContext = createContext<ILocaleContext>({

--- a/src/popup/hooks/useTranslation.ts
+++ b/src/popup/hooks/useTranslation.ts
@@ -2,6 +2,7 @@ import enMessages from '../../_locales/en/messages.json';
 import esMessages from '../../_locales/es/messages.json';
 import deMessages from '../../_locales/de/messages.json';
 import frMessages from '../../_locales/fr/messages.json';
+import jaMessages from '../../_locales/ja/messages.json';
 import { useLocaleContext } from '../context/LocaleContext';
 import { LocaleCode, MessagesType } from '../../types/translations';
 
@@ -11,6 +12,7 @@ const localeMap: Record<LocaleCode, MessagesType> = {
   es: esMessages,
   fr: frMessages,
   de: deMessages,
+  ja: jaMessages,
 };
 
 /**

--- a/src/popup/hooks/useTranslation.ts
+++ b/src/popup/hooks/useTranslation.ts
@@ -1,19 +1,6 @@
+import { localeMap } from '../locales';
 import enMessages from '../../_locales/en/messages.json';
-import esMessages from '../../_locales/es/messages.json';
-import deMessages from '../../_locales/de/messages.json';
-import frMessages from '../../_locales/fr/messages.json';
-import jaMessages from '../../_locales/ja/messages.json';
 import { useLocaleContext } from '../context/LocaleContext';
-import { LocaleCode, MessagesType } from '../../types/translations';
-
-// Map of locale codes to their respective message objects
-const localeMap: Record<LocaleCode, MessagesType> = {
-  en: enMessages,
-  es: esMessages,
-  fr: frMessages,
-  de: deMessages,
-  ja: jaMessages,
-};
 
 /**
  * Custom hook to provide translation functionality based on the current locale.

--- a/src/popup/locales.ts
+++ b/src/popup/locales.ts
@@ -1,0 +1,14 @@
+import enMessages from '../_locales/en/messages.json';
+import esMessages from '../_locales/es/messages.json';
+import frMessages from '../_locales/fr/messages.json';
+import deMessages from '../_locales/de/messages.json';
+import jaMessages from '../_locales/ja/messages.json';
+import { LocaleCode, MessagesType } from '../types/translations';
+
+export const localeMap: Record<LocaleCode, MessagesType> = {
+  en: enMessages,
+  es: esMessages,
+  fr: frMessages,
+  de: deMessages,
+  ja: jaMessages,
+};

--- a/src/types/translations.d.ts
+++ b/src/types/translations.d.ts
@@ -1,5 +1,5 @@
 /** Locale codes supported by the extension. */
-export type LocaleCode = 'en' | 'es' | 'fr' | 'de';
+export type LocaleCode = 'en' | 'es' | 'fr' | 'de' | 'ja';
 
 /** Type definition for translation messages. */
 export type MessagesType = {

--- a/tests/src/popup/hooks/useTranslation.test.ts
+++ b/tests/src/popup/hooks/useTranslation.test.ts
@@ -1,0 +1,62 @@
+import { LocaleCode } from 'types/translations';
+
+jest.mock('popup/context/LocaleContext', () => ({
+  useLocaleContext: jest.fn(),
+}));
+
+import { useLocaleContext } from 'popup/context/LocaleContext';
+import { useTranslation } from 'popup/hooks/useTranslation';
+
+const mockLocale = (locale: LocaleCode) => {
+  (useLocaleContext as jest.Mock).mockReturnValue({ locale, changeLocale: jest.fn() });
+};
+
+describe('useTranslation', () => {
+  it('returns English translations when locale is en', () => {
+    mockLocale('en');
+    const { translate } = useTranslation();
+    expect(translate('enabled')).toBe('On');
+    expect(translate('disabled')).toBe('Off');
+  });
+
+  it('returns Japanese translations when locale is ja', () => {
+    mockLocale('ja');
+    const { translate } = useTranslation();
+    expect(translate('enabled')).toBe('オン');
+    expect(translate('disabled')).toBe('オフ');
+  });
+
+  it('returns German translations when locale is de', () => {
+    mockLocale('de');
+    const { translate } = useTranslation();
+    expect(translate('enabled')).toBe('Ein');
+    expect(translate('disabled')).toBe('Aus');
+  });
+
+  it('returns Spanish translations when locale is es', () => {
+    mockLocale('es');
+    const { translate } = useTranslation();
+    expect(translate('enabled')).toBe('Activado');
+    expect(translate('disabled')).toBe('Desactivado');
+  });
+
+  it('returns French translations when locale is fr', () => {
+    mockLocale('fr');
+    const { translate } = useTranslation();
+    expect(translate('enabled')).toBe('Activé');
+    expect(translate('disabled')).toBe('Désactivé');
+  });
+
+  it('falls back to the key name for unknown keys', () => {
+    mockLocale('en');
+    const { translate } = useTranslation();
+    expect(translate('nonExistentKey')).toBe('nonExistentKey');
+  });
+
+  it('interpolates variables into the message', () => {
+    mockLocale('en');
+    const { translate } = useTranslation();
+    const result = translate('currentVersion', { version: '2.0.0' });
+    expect(result).toContain('2.0.0');
+  });
+});

--- a/tests/src/popup/locales.test.ts
+++ b/tests/src/popup/locales.test.ts
@@ -1,0 +1,31 @@
+import { localeMap } from 'popup/locales';
+
+const locales = Object.keys(localeMap) as (keyof typeof localeMap)[];
+const enKeys = Object.keys(localeMap.en);
+
+describe('localeMap', () => {
+  it('includes English', () => {
+    expect(localeMap).toHaveProperty('en');
+  });
+
+  it('contains all expected locales', () => {
+    expect(locales).toEqual(expect.arrayContaining(['en', 'es', 'fr', 'de', 'ja']));
+  });
+
+  locales.forEach(locale => {
+    describe(`locale: ${locale}`, () => {
+      it('has all English translation keys', () => {
+        const localeKeys = Object.keys(localeMap[locale]);
+        enKeys.forEach(key => {
+          expect(localeKeys).toContain(key);
+        });
+      });
+
+      it('has no empty message values', () => {
+        Object.entries(localeMap[locale]).forEach(([, entry]) => {
+          expect(entry.message.trim()).not.toBe('');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Overview:

This PR expands the extension’s UI localization by adding Japanese support and updates toggle switch labels to be more compact via translation string changes.

**Changes:**
- Add Japanese (`ja`) as a supported locale in types, locale context, popup locale selector, and translation hook mapping.
- Introduce `src/_locales/ja/messages.json` with Japanese translations for all existing message keys.
- Shorten toggle switch labels by updating `enabled`/`disabled` message strings in several locales, and update the changelog.
- Added locales selections tests to ensure the locales are present and everything is translated.
